### PR TITLE
Ensure data.mirrors set for synced brainstorm-topics

### DIFF
--- a/lib/integrations/front.ts
+++ b/lib/integrations/front.ts
@@ -752,6 +752,7 @@ async function getThread(
 	// TEMPORARY code to sync legacy brainstorm topics
 	if (threadType === 'brainstorm-topic@1.0.0') {
 		threadCard.data = {
+			mirrors: [mirrorId],
 			status: 'closed',
 			category: INBOX_TO_BRAINSTORM_CATEGORY[inbox] ?? '',
 			description: '(See timeline)',


### PR DESCRIPTION
This is another temporary change while we pull in legacy brainstorm topics before deleting this code again.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>