### PR TITLE
changes the filter to work with the reworked TA trigger logic

### DIFF
--- a/lib/cards/contrib/triggered-action-integration-front-mirror-event.ts
+++ b/lib/cards/contrib/triggered-action-integration-front-mirror-event.ts
@@ -33,22 +33,37 @@ export const triggeredActionIntegrationFrontMirrorEvent: TriggeredActionContract
 								type: 'string',
 								const: 'support-thread@1.0.0',
 							},
-							data: {
-								type: 'object',
-								required: ['inbox'],
+						},
+						allOf: [
+							{
 								properties: {
-									inbox: {
-										type: 'string',
-										enum: [
-											'S/Paid_Support',
-											'D/Security',
-											'Jellyfish Test Inbox',
-											'Jellyfish Testfront',
-										],
+									// this needs to be specified separately, because we want to run on any changes
+									// within /data
+									data: {
+										type: 'object',
 									},
 								},
 							},
-						},
+							{
+								properties: {
+									data: {
+										type: 'object',
+										required: ['inbox', 'mirrors'],
+										properties: {
+											inbox: {
+												type: 'string',
+												enum: [
+													'S/Paid_Support',
+													'D/Security',
+													'Jellyfish Test Inbox',
+													'Jellyfish Testfront',
+												],
+											},
+										},
+									},
+								},
+							},
+						],
 					},
 				],
 			},


### PR DESCRIPTION
this changes the filter to work with the reworked TA trigger logic, which only triggers if a referenced path is changed

Change-type: minor