### PR TITLE
Remove unneeded vars from test.env

### DIFF
--- a/test.env
+++ b/test.env
@@ -1,3 +1,1 @@
 # This dotenv file is used with docker-compose.test.yml for testing purposes.
-TEST_INTEGRATION_FRONT_INBOX_1=inb_qf8q
-TEST_INTEGRATION_FRONT_INBOX_2=inb_8t8y


### PR DESCRIPTION
The values defined in test.env are now the
defaults defined in jellyfish-environment.

Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>