### PR TITLE
Sync sales-threads

### DIFF
--- a/lib/contracts/triggered-action-integration-front-mirror-event.ts
+++ b/lib/contracts/triggered-action-integration-front-mirror-event.ts
@@ -22,7 +22,7 @@ export const triggeredActionIntegrationFrontMirrorEvent: TriggeredActionContract
 						type: 'object',
 						properties: {
 							type: {
-								const: 'support-thread@1.0.0',
+								enum: ['support-thread@1.0.0', 'sales-thread@1.0.0'],
 							},
 							data: {
 								type: 'object',

--- a/lib/contracts/triggered-action-integration-front-mirror-thread.ts
+++ b/lib/contracts/triggered-action-integration-front-mirror-thread.ts
@@ -13,7 +13,7 @@ export const triggeredActionIntegrationFrontMirrorThread: TriggeredActionContrac
 				properties: {
 					type: {
 						type: 'string',
-						const: 'support-thread@1.0.0',
+						enum: ['support-thread@1.0.0', 'sales-thread@1.0.0'],
 					},
 				},
 				allOf: [


### PR DESCRIPTION
This change fixes a bug where sales threads would not be matched by the
mirror triggers.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>