### PR TITLE
Speed up tests by not saving redis store to disk

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     command: ['postgres', '-c', 'fsync=off', '-c', 'synchronous_commit=off', '-c', 'full_page_writes=off']
   redis:
     image: redis:7
-    command: redis-server --appendonly yes
+    command: redis-server --save "" --appendonly no
     restart: always
     networks:
       - internal


### PR DESCRIPTION
Since the redis instance is only used for tests and development, its
fine to skip writing to disk in favour of more speed.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>