### PR TITLE
Stop using deprecated marked HTML sanitizer

### DIFF
--- a/lib/integrations/front.ts
+++ b/lib/integrations/front.ts
@@ -12,6 +12,7 @@ import * as Intercom from 'intercom-client';
 import _ from 'lodash';
 import LRU from 'lru-cache';
 import { marked } from 'marked';
+import sanitizeHtml from 'sanitize-html';
 import * as utils from './utils';
 
 // tslint:disable: no-var-requires
@@ -1512,13 +1513,14 @@ export class FrontIntegration implements Integration {
 			if (baseType === 'message') {
 				const conversation: string = _.last(threadFrontUrl.split('/')) || '';
 				const message = card.data.payload.message;
-				const html = marked.parse(message, {
+				const rawhtml = marked.parse(message, {
 					// Enable github flavored markdown
 					gfm: true,
 					breaks: true,
 					headerIds: false,
-					sanitize: true,
 				});
+
+				const html = sanitizeHtml(rawhtml);
 
 				this.context.log.info('Creating front message', {
 					conversation,

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@balena/jellyfish-assert": "^1.2.39",
     "@balena/jellyfish-environment": "^12.3.0",
     "@balena/jellyfish-worker": "^32.0.0",
+    "@types/sanitize-html": "^2.6.2",
     "axios": "^0.27.2",
     "bluebird": "^3.7.2",
     "fast-json-patch": "^3.1.1",
@@ -57,7 +58,8 @@
     "lodash": "^4.17.21",
     "lru-cache": "^6.0.0",
     "marked": "^4.0.16",
-    "native-url": "^0.3.4"
+    "native-url": "^0.3.4",
+    "sanitize-html": "^2.7.1"
   },
   "devDependencies": {
     "@balena/jellyfish-logger": "^5.1.7",


### PR DESCRIPTION
This PR switches from using the [deprecated `sanitize` option in marked](https://marked.js.org/using_advanced#options) in favor of sanitizing the html with `sanitize-html`.
I chose `sanitize-html` over the recommended `DOMPurify` package as `DOMPurify` requires you to use JSDom if you want to sanitize html in a NodeJS environment, and this seemed like too much overhead.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>