### PR TITLE
Update and enable all translate tests

### DIFF
--- a/test/integration/webhooks/inbound-archive-unarchive/stubs/1/messages-msg-1-w-1-ghu-2.json
+++ b/test/integration/webhooks/inbound-archive-unarchive/stubs/1/messages-msg-1-w-1-ghu-2.json
@@ -1,0 +1,40 @@
+{
+    "_links": {
+      "self": "https://api2.frontapp.com/messages/msg_1w1ghu2",
+      "related": {
+        "conversation": "https://api2.frontapp.com/conversations/cnv_11dwyua"
+      }
+    },
+    "id": "msg_1w1ghu2",
+    "type": "email",
+    "is_inbound": true,
+    "created_at": 1539024594.763,
+    "blurb": " ",
+    "body": "<div><br /></div>\n",
+    "text": "\n",
+    "is_draft": false,
+    "error_type": null,
+    "metadata": {},
+    "author": null,
+    "recipients": [
+      {
+        "_links": {
+          "related": {
+            "contact": null
+          }
+        },
+        "handle": "juan@resin.io",
+        "role": "from"
+      },
+      {
+        "_links": {
+          "related": {
+            "contact": "https://api2.frontapp.com/contacts/crd_hgkpe"
+          }
+        },
+        "handle": "26ww-resin_io_dev@in.frontapp.com",
+        "role": "to"
+      }
+    ],
+    "attachments": []
+}

--- a/test/integration/webhooks/inbound-archive/stubs/1/messages-msg-1-w-1-emp-6.json
+++ b/test/integration/webhooks/inbound-archive/stubs/1/messages-msg-1-w-1-emp-6.json
@@ -1,0 +1,40 @@
+{
+    "_links": {
+      "self": "https://api2.frontapp.com/messages/msg_1w1emp6",
+      "related": {
+        "conversation": "https://api2.frontapp.com/conversations/cnv_11dvpbu"
+      }
+    },
+    "id": "msg_1w1emp6",
+    "type": "email",
+    "is_inbound": true,
+    "created_at": 1539023564.69,
+    "blurb": " Hello ",
+    "body": "<div>Hello</div>\n",
+    "text": "Hello\n",
+    "is_draft": false,
+    "error_type": null,
+    "metadata": {},
+    "author": null,
+    "recipients": [
+      {
+        "_links": {
+          "related": {
+            "contact": null
+          }
+        },
+        "handle": "juan@resin.io",
+        "role": "from"
+      },
+      {
+        "_links": {
+          "related": {
+            "contact": "https://api2.frontapp.com/contacts/crd_hgkpe"
+          }
+        },
+        "handle": "26ww-resin_io_dev@in.frontapp.com",
+        "role": "to"
+      }
+    ],
+    "attachments": []
+}

--- a/test/integration/webhooks/inbound-attachment/stubs/1/messages-msg-2-irqbh-7.json
+++ b/test/integration/webhooks/inbound-attachment/stubs/1/messages-msg-2-irqbh-7.json
@@ -1,0 +1,42 @@
+{
+    "_links": {
+      "self": "https://api2.frontapp.com/messages/msg_2irqbh7",
+      "related": {
+        "conversation": "https://api2.frontapp.com/conversations/cnv_1bd652j"
+      }
+    },
+    "id": "msg_2irqbh7",
+    "type": "intercom",
+    "is_inbound": true,
+    "created_at": 1554382242,
+    "blurb": "Attachment test",
+    "body": "<div><p>Attachment test</p>\n</div>",
+    "text": "Attachment test",
+    "is_draft": false,
+    "error_type": null,
+    "metadata": {
+      "intercom_url": "https://app.intercom.io/a/apps/yg02r5dz/inbox/conversation/21490929822"
+    },
+    "author": null,
+    "recipients": [
+      {
+        "_links": {
+          "related": {
+            "contact": null
+          }
+        },
+        "handle": "5457936368f6f465d7002858",
+        "role": "from"
+      },
+      {
+        "_links": {
+          "related": {
+            "contact": "https://api2.frontapp.com/contacts/crd_5gqtnd"
+          }
+        },
+        "handle": "yg02r5dz",
+        "role": "to"
+      }
+    ],
+    "attachments": []
+}

--- a/test/integration/webhooks/inbound-attachment/stubs/3/messages-msg-2-irqd-2-r.json
+++ b/test/integration/webhooks/inbound-attachment/stubs/3/messages-msg-2-irqd-2-r.json
@@ -1,0 +1,52 @@
+{
+    "_links": {
+      "self": "https://api2.frontapp.com/messages/msg_2irqd2r",
+      "related": {
+        "conversation": "https://api2.frontapp.com/conversations/cnv_1bd652j"
+      }
+    },
+    "id": "msg_2irqd2r",
+    "type": "intercom",
+    "is_inbound": true,
+    "created_at": 1554382265,
+    "blurb": "",
+    "body": "<div></div>",
+    "text": "",
+    "is_draft": false,
+    "error_type": null,
+    "metadata": {
+      "intercom_url": "https://app.intercom.io/a/apps/yg02r5dz/inbox/conversation/21490929822"
+    },
+    "author": null,
+    "recipients": [
+      {
+        "_links": {
+          "related": {
+            "contact": null
+          }
+        },
+        "handle": "5457936368f6f465d7002858",
+        "role": "from"
+      },
+      {
+        "_links": {
+          "related": {
+            "contact": "https://api2.frontapp.com/contacts/crd_5gqtnd"
+          }
+        },
+        "handle": "yg02r5dz",
+        "role": "to"
+      }
+    ],
+    "attachments": [
+      {
+        "url": "https://api2.frontapp.com/download/fil_375dw9f",
+        "filename": "webhooks.tar.xz",
+        "content_type": "application/force-download",
+        "size": 1700,
+        "metadata": {
+          "is_inline": false
+        }
+      }
+    ]
+}

--- a/test/integration/webhooks/inbound-attachment/stubs/4/messages-msg-2-irqdgz.json
+++ b/test/integration/webhooks/inbound-attachment/stubs/4/messages-msg-2-irqdgz.json
@@ -1,0 +1,52 @@
+{
+    "_links": {
+      "self": "https://api2.frontapp.com/messages/msg_2irqdgz",
+      "related": {
+        "conversation": "https://api2.frontapp.com/conversations/cnv_1bd652j"
+      }
+    },
+    "id": "msg_2irqdgz",
+    "type": "intercom",
+    "is_inbound": true,
+    "created_at": 1554382271,
+    "blurb": "",
+    "body": "<div></div>",
+    "text": "",
+    "is_draft": false,
+    "error_type": null,
+    "metadata": {
+      "intercom_url": "https://app.intercom.io/a/apps/yg02r5dz/inbox/conversation/21490929822"
+    },
+    "author": null,
+    "recipients": [
+      {
+        "_links": {
+          "related": {
+            "contact": null
+          }
+        },
+        "handle": "5457936368f6f465d7002858",
+        "role": "from"
+      },
+      {
+        "_links": {
+          "related": {
+            "contact": "https://api2.frontapp.com/contacts/crd_5gqtnd"
+          }
+        },
+        "handle": "yg02r5dz",
+        "role": "to"
+      }
+    ],
+    "attachments": [
+      {
+        "url": "https://api2.frontapp.com/download/fil_375dxfn",
+        "filename": "webpack.config.js",
+        "content_type": "text/plain",
+        "size": 2818,
+        "metadata": {
+          "is_inline": false
+        }
+      }
+    ]
+}

--- a/test/integration/webhooks/inbound-comment-edit-blank/stubs/1/messages-msg-2-ged-8-ve.json
+++ b/test/integration/webhooks/inbound-comment-edit-blank/stubs/1/messages-msg-2-ged-8-ve.json
@@ -1,0 +1,40 @@
+{
+    "_links": {
+      "self": "https://api2.frontapp.com/messages/msg_2ged8ve",
+      "related": {
+        "conversation": "https://api2.frontapp.com/conversations/cnv_1bolr9e"
+      }
+    },
+    "id": "msg_2ged8ve",
+    "type": "email",
+    "is_inbound": true,
+    "created_at": 1552506860.108,
+    "blurb": " Foo Bar ",
+    "body": "<div>Foo Bar</div>\n",
+    "text": "Foo Bar\n",
+    "is_draft": false,
+    "error_type": null,
+    "metadata": {},
+    "author": null,
+    "recipients": [
+      {
+        "_links": {
+          "related": {
+            "contact": null
+          }
+        },
+        "handle": "juan@balena.io",
+        "role": "from"
+      },
+      {
+        "_links": {
+          "related": {
+            "contact": "https://api2.frontapp.com/contacts/crd_hgkpe"
+          }
+        },
+        "handle": "26ww-resin_io_dev@in.frontapp.com",
+        "role": "to"
+      }
+    ],
+    "attachments": []
+}

--- a/test/integration/webhooks/inbound-comment-edit/stubs/1/messages-msg-2-ged-8-ve.json
+++ b/test/integration/webhooks/inbound-comment-edit/stubs/1/messages-msg-2-ged-8-ve.json
@@ -1,0 +1,40 @@
+{
+    "_links": {
+      "self": "https://api2.frontapp.com/messages/msg_2ged8ve",
+      "related": {
+        "conversation": "https://api2.frontapp.com/conversations/cnv_1bolr9e"
+      }
+    },
+    "id": "msg_2ged8ve",
+    "type": "email",
+    "is_inbound": true,
+    "created_at": 1552506860.108,
+    "blurb": " Foo Bar ",
+    "body": "<div>Foo Bar</div>\n",
+    "text": "Foo Bar\n",
+    "is_draft": false,
+    "error_type": null,
+    "metadata": {},
+    "author": null,
+    "recipients": [
+      {
+        "_links": {
+          "related": {
+            "contact": null
+          }
+        },
+        "handle": "juan@balena.io",
+        "role": "from"
+      },
+      {
+        "_links": {
+          "related": {
+            "contact": "https://api2.frontapp.com/contacts/crd_hgkpe"
+          }
+        },
+        "handle": "26ww-resin_io_dev@in.frontapp.com",
+        "role": "to"
+      }
+    ],
+    "attachments": []
+}

--- a/test/integration/webhooks/inbound-delay-message-cancel/01.json
+++ b/test/integration/webhooks/inbound-delay-message-cancel/01.json
@@ -25,7 +25,8 @@
           "followers": "https://api2.frontapp.com/conversations/cnv_11sgs3f/followers",
           "messages": "https://api2.frontapp.com/conversations/cnv_11sgs3f/messages",
           "comments": "https://api2.frontapp.com/conversations/cnv_11sgs3f/comments",
-          "inboxes": "https://api2.frontapp.com/conversations/cnv_11sgs3f/inboxes"
+          "inboxes": "https://api2.frontapp.com/conversations/cnv_11sgs3f/inboxes",
+          "last_message": "https://api2.frontapp.com/messages/msg_1y9m7wr"
         }
       },
       "id": "cnv_11sgs3f",
@@ -42,46 +43,6 @@
         "role": "from"
       },
       "tags": [],
-      "last_message": {
-        "_links": {
-          "self": "https://api2.frontapp.com/messages/msg_1y9m7wr",
-          "related": {
-            "conversation": "https://api2.frontapp.com/conversations/cnv_11sgs3f"
-          }
-        },
-        "id": "msg_1y9m7wr",
-        "type": "email",
-        "is_inbound": true,
-        "created_at": 1539209958.154,
-        "blurb": " Test ",
-        "body": "<div>Test</div>\n",
-        "text": "Test\n",
-        "is_draft": false,
-        "error_type": null,
-        "metadata": {},
-        "author": null,
-        "recipients": [
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_5ef35"
-              }
-            },
-            "handle": "juan@resin.io",
-            "role": "from"
-          },
-          {
-            "_links": {
-              "related": {
-                "contact": null
-              }
-            },
-            "handle": "ei8z-resin_io@in.frontapp.com",
-            "role": "to"
-          }
-        ],
-        "attachments": []
-      },
       "created_at": 1539209958.438,
       "is_private": false
     },

--- a/test/integration/webhooks/inbound-delay-message-cancel/02.json
+++ b/test/integration/webhooks/inbound-delay-message-cancel/02.json
@@ -25,7 +25,8 @@
           "followers": "https://api2.frontapp.com/conversations/cnv_11sgs3f/followers",
           "messages": "https://api2.frontapp.com/conversations/cnv_11sgs3f/messages",
           "comments": "https://api2.frontapp.com/conversations/cnv_11sgs3f/comments",
-          "inboxes": "https://api2.frontapp.com/conversations/cnv_11sgs3f/inboxes"
+          "inboxes": "https://api2.frontapp.com/conversations/cnv_11sgs3f/inboxes",
+          "last_message": "https://api2.frontapp.com/messages/msg_1y9m7wr"
         }
       },
       "id": "cnv_11sgs3f",
@@ -57,46 +58,6 @@
         "role": "to"
       },
       "tags": [],
-      "last_message": {
-        "_links": {
-          "self": "https://api2.frontapp.com/messages/msg_1y9m7wr",
-          "related": {
-            "conversation": "https://api2.frontapp.com/conversations/cnv_11sgs3f"
-          }
-        },
-        "id": "msg_1y9m7wr",
-        "type": "email",
-        "is_inbound": true,
-        "created_at": 1539209958.154,
-        "blurb": " Test ",
-        "body": "<div>Test</div>\n",
-        "text": "Test\n",
-        "is_draft": false,
-        "error_type": null,
-        "metadata": {},
-        "author": null,
-        "recipients": [
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_5ef35"
-              }
-            },
-            "handle": "juan@resin.io",
-            "role": "from"
-          },
-          {
-            "_links": {
-              "related": {
-                "contact": null
-              }
-            },
-            "handle": "ei8z-resin_io@in.frontapp.com",
-            "role": "to"
-          }
-        ],
-        "attachments": []
-      },
       "created_at": 1539209958.438,
       "is_private": false
     },

--- a/test/integration/webhooks/inbound-delay-message-cancel/stubs/1/messages-msg-1-y-9-m-7-wr.json
+++ b/test/integration/webhooks/inbound-delay-message-cancel/stubs/1/messages-msg-1-y-9-m-7-wr.json
@@ -1,0 +1,40 @@
+{
+    "_links": {
+      "self": "https://api2.frontapp.com/messages/msg_1y9m7wr",
+      "related": {
+        "conversation": "https://api2.frontapp.com/conversations/cnv_11sgs3f"
+      }
+    },
+    "id": "msg_1y9m7wr",
+    "type": "email",
+    "is_inbound": true,
+    "created_at": 1539209958.154,
+    "blurb": " Test ",
+    "body": "<div>Test</div>\n",
+    "text": "Test\n",
+    "is_draft": false,
+    "error_type": null,
+    "metadata": {},
+    "author": null,
+    "recipients": [
+      {
+        "_links": {
+          "related": {
+            "contact": "https://api2.frontapp.com/contacts/crd_5ef35"
+          }
+        },
+        "handle": "juan@resin.io",
+        "role": "from"
+      },
+      {
+        "_links": {
+          "related": {
+            "contact": null
+          }
+        },
+        "handle": "ei8z-resin_io@in.frontapp.com",
+        "role": "to"
+      }
+    ],
+    "attachments": []
+}

--- a/test/integration/webhooks/inbound-delay-message/01.json
+++ b/test/integration/webhooks/inbound-delay-message/01.json
@@ -25,7 +25,8 @@
           "followers": "https://api2.frontapp.com/conversations/cnv_11sdsiz/followers",
           "messages": "https://api2.frontapp.com/conversations/cnv_11sdsiz/messages",
           "comments": "https://api2.frontapp.com/conversations/cnv_11sdsiz/comments",
-          "inboxes": "https://api2.frontapp.com/conversations/cnv_11sdsiz/inboxes"
+          "inboxes": "https://api2.frontapp.com/conversations/cnv_11sdsiz/inboxes",
+          "last_message": "https://api2.frontapp.com/messages/msg_1y9f9ir"
         }
       },
       "id": "cnv_11sdsiz",
@@ -42,46 +43,6 @@
         "role": "from"
       },
       "tags": [],
-      "last_message": {
-        "_links": {
-          "self": "https://api2.frontapp.com/messages/msg_1y9f9ir",
-          "related": {
-            "conversation": "https://api2.frontapp.com/conversations/cnv_11sdsiz"
-          }
-        },
-        "id": "msg_1y9f9ir",
-        "type": "email",
-        "is_inbound": true,
-        "created_at": 1539207591.256,
-        "blurb": " Hello ",
-        "body": "<div>Hello</div>\n",
-        "text": "Hello\n",
-        "is_draft": false,
-        "error_type": null,
-        "metadata": {},
-        "author": null,
-        "recipients": [
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_5ef35"
-              }
-            },
-            "handle": "juan@resin.io",
-            "role": "from"
-          },
-          {
-            "_links": {
-              "related": {
-                "contact": null
-              }
-            },
-            "handle": "ei8z-resin_io@in.frontapp.com",
-            "role": "to"
-          }
-        ],
-        "attachments": []
-      },
       "created_at": 1539207591.388,
       "is_private": false
     },

--- a/test/integration/webhooks/inbound-delay-message/02.json
+++ b/test/integration/webhooks/inbound-delay-message/02.json
@@ -25,7 +25,8 @@
           "followers": "https://api2.frontapp.com/conversations/cnv_11sdsiz/followers",
           "messages": "https://api2.frontapp.com/conversations/cnv_11sdsiz/messages",
           "comments": "https://api2.frontapp.com/conversations/cnv_11sdsiz/comments",
-          "inboxes": "https://api2.frontapp.com/conversations/cnv_11sdsiz/inboxes"
+          "inboxes": "https://api2.frontapp.com/conversations/cnv_11sdsiz/inboxes",
+          "last_message": "https://api2.frontapp.com/messages/msg_1y9f9ir"
         }
       },
       "id": "cnv_11sdsiz",
@@ -57,46 +58,6 @@
         "role": "to"
       },
       "tags": [],
-      "last_message": {
-        "_links": {
-          "self": "https://api2.frontapp.com/messages/msg_1y9f9ir",
-          "related": {
-            "conversation": "https://api2.frontapp.com/conversations/cnv_11sdsiz"
-          }
-        },
-        "id": "msg_1y9f9ir",
-        "type": "email",
-        "is_inbound": true,
-        "created_at": 1539207591.256,
-        "blurb": " Hello ",
-        "body": "<div>Hello</div>\n",
-        "text": "Hello\n",
-        "is_draft": false,
-        "error_type": null,
-        "metadata": {},
-        "author": null,
-        "recipients": [
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_5ef35"
-              }
-            },
-            "handle": "juan@resin.io",
-            "role": "from"
-          },
-          {
-            "_links": {
-              "related": {
-                "contact": null
-              }
-            },
-            "handle": "ei8z-resin_io@in.frontapp.com",
-            "role": "to"
-          }
-        ],
-        "attachments": []
-      },
       "created_at": 1539207591.388,
       "is_private": false
     },

--- a/test/integration/webhooks/inbound-delay-message/03.json
+++ b/test/integration/webhooks/inbound-delay-message/03.json
@@ -25,7 +25,8 @@
           "followers": "https://api2.frontapp.com/conversations/cnv_11sdsiz/followers",
           "messages": "https://api2.frontapp.com/conversations/cnv_11sdsiz/messages",
           "comments": "https://api2.frontapp.com/conversations/cnv_11sdsiz/comments",
-          "inboxes": "https://api2.frontapp.com/conversations/cnv_11sdsiz/inboxes"
+          "inboxes": "https://api2.frontapp.com/conversations/cnv_11sdsiz/inboxes",
+          "last_message": "https://api2.frontapp.com/messages/msg_1y9fb8z"
         }
       },
       "id": "cnv_11sdsiz",
@@ -57,61 +58,6 @@
         "role": "to"
       },
       "tags": [],
-      "last_message": {
-        "_links": {
-          "self": "https://api2.frontapp.com/messages/msg_1y9fb8z",
-          "related": {
-            "conversation": "https://api2.frontapp.com/conversations/cnv_11sdsiz"
-          }
-        },
-        "id": "msg_1y9fb8z",
-        "type": "email",
-        "is_inbound": false,
-        "created_at": 1539208210.973,
-        "blurb": "Hey there! ",
-        "body": "<div>Hey there!</div><br><div class=\"front-signature fa-uid_08dbba14523ca30f8679c237594b5e21\">—<br />Juan Cruz Viotti,<div>Software Engineer, Resin.io (https://resin.io)</div><div>twt: @resin_io</div></div><br><blockquote type=\"cite\" class=\"front-blockquote\">On Wed, Oct 10, 2018 at 10:39 pm,  &lt;<a href=\"mailto:juan@resin.io\" target=\"_blank\" rel=\"noopener noreferrer\">juan@resin.io</a>&gt; Juan Cruz Viotti wrote:<br /><br /><div id=\"fae_1y9fb8z-ftkyv6\"><div>Hello</div>\n</div></blockquote>",
-        "text": "Hey there!\n",
-        "is_draft": false,
-        "error_type": null,
-        "metadata": {},
-        "author": {
-          "_links": {
-            "self": "https://api2.frontapp.com/teammates/tea_grc",
-            "related": {
-              "inboxes": "https://api2.frontapp.com/teammates/tea_grc/inboxes",
-              "conversations": "https://api2.frontapp.com/teammates/tea_grc/conversations"
-            }
-          },
-          "id": "tea_grc",
-          "email": "juan@resin.io",
-          "username": "jviotti",
-          "first_name": "Juan Cruz",
-          "last_name": "Viotti",
-          "is_admin": true,
-          "is_available": true
-        },
-        "recipients": [
-          {
-            "_links": {
-              "related": {
-                "contact": null
-              }
-            },
-            "handle": "test@resin.io",
-            "role": "from"
-          },
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_5ef35"
-              }
-            },
-            "handle": "juan@resin.io",
-            "role": "to"
-          }
-        ],
-        "attachments": []
-      },
       "created_at": 1539207591.388,
       "is_private": false
     },

--- a/test/integration/webhooks/inbound-delay-message/stubs/1/messages-msg-1-y-9-f-9-ir.json
+++ b/test/integration/webhooks/inbound-delay-message/stubs/1/messages-msg-1-y-9-f-9-ir.json
@@ -1,0 +1,40 @@
+{
+    "_links": {
+      "self": "https://api2.frontapp.com/messages/msg_1y9f9ir",
+      "related": {
+        "conversation": "https://api2.frontapp.com/conversations/cnv_11sdsiz"
+      }
+    },
+    "id": "msg_1y9f9ir",
+    "type": "email",
+    "is_inbound": true,
+    "created_at": 1539207591.256,
+    "blurb": " Hello ",
+    "body": "<div>Hello</div>\n",
+    "text": "Hello\n",
+    "is_draft": false,
+    "error_type": null,
+    "metadata": {},
+    "author": null,
+    "recipients": [
+      {
+        "_links": {
+          "related": {
+            "contact": "https://api2.frontapp.com/contacts/crd_5ef35"
+          }
+        },
+        "handle": "juan@resin.io",
+        "role": "from"
+      },
+      {
+        "_links": {
+          "related": {
+            "contact": null
+          }
+        },
+        "handle": "ei8z-resin_io@in.frontapp.com",
+        "role": "to"
+      }
+    ],
+    "attachments": []
+}

--- a/test/integration/webhooks/inbound-delay-message/stubs/3/messages-msg-1-y-9-fb-8-z.json
+++ b/test/integration/webhooks/inbound-delay-message/stubs/3/messages-msg-1-y-9-fb-8-z.json
@@ -1,0 +1,55 @@
+{
+    "_links": {
+      "self": "https://api2.frontapp.com/messages/msg_1y9fb8z",
+      "related": {
+        "conversation": "https://api2.frontapp.com/conversations/cnv_11sdsiz"
+      }
+    },
+    "id": "msg_1y9fb8z",
+    "type": "email",
+    "is_inbound": false,
+    "created_at": 1539208210.973,
+    "blurb": "Hey there! ",
+    "body": "<div>Hey there!</div><br><div class=\"front-signature fa-uid_08dbba14523ca30f8679c237594b5e21\">—<br />Juan Cruz Viotti,<div>Software Engineer, Resin.io (https://resin.io)</div><div>twt: @resin_io</div></div><br><blockquote type=\"cite\" class=\"front-blockquote\">On Wed, Oct 10, 2018 at 10:39 pm,  &lt;<a href=\"mailto:juan@resin.io\" target=\"_blank\" rel=\"noopener noreferrer\">juan@resin.io</a>&gt; Juan Cruz Viotti wrote:<br /><br /><div id=\"fae_1y9fb8z-ftkyv6\"><div>Hello</div>\n</div></blockquote>",
+    "text": "Hey there!\n",
+    "is_draft": false,
+    "error_type": null,
+    "metadata": {},
+    "author": {
+      "_links": {
+        "self": "https://api2.frontapp.com/teammates/tea_grc",
+        "related": {
+          "inboxes": "https://api2.frontapp.com/teammates/tea_grc/inboxes",
+          "conversations": "https://api2.frontapp.com/teammates/tea_grc/conversations"
+        }
+      },
+      "id": "tea_grc",
+      "email": "juan@resin.io",
+      "username": "jviotti",
+      "first_name": "Juan Cruz",
+      "last_name": "Viotti",
+      "is_admin": true,
+      "is_available": true
+    },
+    "recipients": [
+      {
+        "_links": {
+          "related": {
+            "contact": null
+          }
+        },
+        "handle": "test@resin.io",
+        "role": "from"
+      },
+      {
+        "_links": {
+          "related": {
+            "contact": "https://api2.frontapp.com/contacts/crd_5ef35"
+          }
+        },
+        "handle": "juan@resin.io",
+        "role": "to"
+      }
+    ],
+    "attachments": []
+}

--- a/test/integration/webhooks/inbound-delete-message/01.json
+++ b/test/integration/webhooks/inbound-delete-message/01.json
@@ -25,7 +25,8 @@
           "followers": "https://api2.frontapp.com/conversations/cnv_11she63/followers",
           "messages": "https://api2.frontapp.com/conversations/cnv_11she63/messages",
           "comments": "https://api2.frontapp.com/conversations/cnv_11she63/comments",
-          "inboxes": "https://api2.frontapp.com/conversations/cnv_11she63/inboxes"
+          "inboxes": "https://api2.frontapp.com/conversations/cnv_11she63/inboxes",
+          "last_message": "https://api2.frontapp.com/messages/msg_1y9npub"
         }
       },
       "id": "cnv_11she63",
@@ -42,46 +43,6 @@
         "role": "from"
       },
       "tags": [],
-      "last_message": {
-        "_links": {
-          "self": "https://api2.frontapp.com/messages/msg_1y9npub",
-          "related": {
-            "conversation": "https://api2.frontapp.com/conversations/cnv_11she63"
-          }
-        },
-        "id": "msg_1y9npub",
-        "type": "email",
-        "is_inbound": true,
-        "created_at": 1539210518.044,
-        "blurb": " Hello ",
-        "body": "<div>Hello</div>\n",
-        "text": "Hello\n",
-        "is_draft": false,
-        "error_type": null,
-        "metadata": {},
-        "author": null,
-        "recipients": [
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_5ef35"
-              }
-            },
-            "handle": "juan@resin.io",
-            "role": "from"
-          },
-          {
-            "_links": {
-              "related": {
-                "contact": null
-              }
-            },
-            "handle": "ei8z-resin_io@in.frontapp.com",
-            "role": "to"
-          }
-        ],
-        "attachments": []
-      },
       "created_at": 1539210518.211,
       "is_private": false
     },

--- a/test/integration/webhooks/inbound-delete-message/02.json
+++ b/test/integration/webhooks/inbound-delete-message/02.json
@@ -25,7 +25,8 @@
           "followers": "https://api2.frontapp.com/conversations/cnv_11she63/followers",
           "messages": "https://api2.frontapp.com/conversations/cnv_11she63/messages",
           "comments": "https://api2.frontapp.com/conversations/cnv_11she63/comments",
-          "inboxes": "https://api2.frontapp.com/conversations/cnv_11she63/inboxes"
+          "inboxes": "https://api2.frontapp.com/conversations/cnv_11she63/inboxes",
+          "last_message": "https://api2.frontapp.com/messages/msg_1y9npub"
         }
       },
       "id": "cnv_11she63",
@@ -42,46 +43,6 @@
         "role": "from"
       },
       "tags": [],
-      "last_message": {
-        "_links": {
-          "self": "https://api2.frontapp.com/messages/msg_1y9npub",
-          "related": {
-            "conversation": "https://api2.frontapp.com/conversations/cnv_11she63"
-          }
-        },
-        "id": "msg_1y9npub",
-        "type": "email",
-        "is_inbound": true,
-        "created_at": 1539210518.044,
-        "blurb": " Hello ",
-        "body": "<div>Hello</div>\n",
-        "text": "Hello\n",
-        "is_draft": false,
-        "error_type": null,
-        "metadata": {},
-        "author": null,
-        "recipients": [
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_5ef35"
-              }
-            },
-            "handle": "juan@resin.io",
-            "role": "from"
-          },
-          {
-            "_links": {
-              "related": {
-                "contact": null
-              }
-            },
-            "handle": "ei8z-resin_io@in.frontapp.com",
-            "role": "to"
-          }
-        ],
-        "attachments": []
-      },
       "created_at": 1539210518.211,
       "is_private": false
     },

--- a/test/integration/webhooks/inbound-delete-message/03.json
+++ b/test/integration/webhooks/inbound-delete-message/03.json
@@ -25,7 +25,8 @@
           "followers": "https://api2.frontapp.com/conversations/cnv_11she63/followers",
           "messages": "https://api2.frontapp.com/conversations/cnv_11she63/messages",
           "comments": "https://api2.frontapp.com/conversations/cnv_11she63/comments",
-          "inboxes": "https://api2.frontapp.com/conversations/cnv_11she63/inboxes"
+          "inboxes": "https://api2.frontapp.com/conversations/cnv_11she63/inboxes",
+          "last_message": "https://api2.frontapp.com/messages/msg_1y9npub"
         }
       },
       "id": "cnv_11she63",
@@ -57,46 +58,6 @@
         "role": "to"
       },
       "tags": [],
-      "last_message": {
-        "_links": {
-          "self": "https://api2.frontapp.com/messages/msg_1y9npub",
-          "related": {
-            "conversation": "https://api2.frontapp.com/conversations/cnv_11she63"
-          }
-        },
-        "id": "msg_1y9npub",
-        "type": "email",
-        "is_inbound": true,
-        "created_at": 1539210518.044,
-        "blurb": " Hello ",
-        "body": "<div>Hello</div>\n",
-        "text": "Hello\n",
-        "is_draft": false,
-        "error_type": null,
-        "metadata": {},
-        "author": null,
-        "recipients": [
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_5ef35"
-              }
-            },
-            "handle": "juan@resin.io",
-            "role": "from"
-          },
-          {
-            "_links": {
-              "related": {
-                "contact": null
-              }
-            },
-            "handle": "ei8z-resin_io@in.frontapp.com",
-            "role": "to"
-          }
-        ],
-        "attachments": []
-      },
       "created_at": 1539210518.211,
       "is_private": false
     },

--- a/test/integration/webhooks/inbound-delete-message/04.json
+++ b/test/integration/webhooks/inbound-delete-message/04.json
@@ -25,7 +25,8 @@
           "followers": "https://api2.frontapp.com/conversations/cnv_11she63/followers",
           "messages": "https://api2.frontapp.com/conversations/cnv_11she63/messages",
           "comments": "https://api2.frontapp.com/conversations/cnv_11she63/comments",
-          "inboxes": "https://api2.frontapp.com/conversations/cnv_11she63/inboxes"
+          "inboxes": "https://api2.frontapp.com/conversations/cnv_11she63/inboxes",
+          "last_message": "https://api2.frontapp.com/messages/msg_1y9npub"
         }
       },
       "id": "cnv_11she63",
@@ -57,46 +58,6 @@
         "role": "to"
       },
       "tags": [],
-      "last_message": {
-        "_links": {
-          "self": "https://api2.frontapp.com/messages/msg_1y9npub",
-          "related": {
-            "conversation": "https://api2.frontapp.com/conversations/cnv_11she63"
-          }
-        },
-        "id": "msg_1y9npub",
-        "type": "email",
-        "is_inbound": true,
-        "created_at": 1539210518.044,
-        "blurb": " Hello ",
-        "body": "<div>Hello</div>\n",
-        "text": "Hello\n",
-        "is_draft": false,
-        "error_type": null,
-        "metadata": {},
-        "author": null,
-        "recipients": [
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_5ef35"
-              }
-            },
-            "handle": "juan@resin.io",
-            "role": "from"
-          },
-          {
-            "_links": {
-              "related": {
-                "contact": null
-              }
-            },
-            "handle": "ei8z-resin_io@in.frontapp.com",
-            "role": "to"
-          }
-        ],
-        "attachments": []
-      },
       "created_at": 1539210518.211,
       "is_private": false
     },

--- a/test/integration/webhooks/inbound-delete-message/05.json
+++ b/test/integration/webhooks/inbound-delete-message/05.json
@@ -25,7 +25,8 @@
           "followers": "https://api2.frontapp.com/conversations/cnv_11she63/followers",
           "messages": "https://api2.frontapp.com/conversations/cnv_11she63/messages",
           "comments": "https://api2.frontapp.com/conversations/cnv_11she63/comments",
-          "inboxes": "https://api2.frontapp.com/conversations/cnv_11she63/inboxes"
+          "inboxes": "https://api2.frontapp.com/conversations/cnv_11she63/inboxes",
+          "last_message": "https://api2.frontapp.com/messages/msg_1y9nrkr"
         }
       },
       "id": "cnv_11she63",
@@ -57,61 +58,6 @@
         "role": "to"
       },
       "tags": [],
-      "last_message": {
-        "_links": {
-          "self": "https://api2.frontapp.com/messages/msg_1y9nrkr",
-          "related": {
-            "conversation": "https://api2.frontapp.com/conversations/cnv_11she63"
-          }
-        },
-        "id": "msg_1y9nrkr",
-        "type": "email",
-        "is_inbound": false,
-        "created_at": 1539210552.763,
-        "blurb": "Response! ",
-        "body": "<div>Response!</div><br><div class=\"front-signature fa-uid_1adb5fca3c6ea641296a83c893eddfa6\">—<br />Juan Cruz Viotti,<div>Software Engineer, Resin.io (https://resin.io)</div><div>twt: @resin_io</div></div><br><blockquote type=\"cite\" class=\"front-blockquote\">On Wed, Oct 10, 2018 at 11:28 pm,  &lt;<a href=\"mailto:juan@resin.io\" target=\"_blank\" rel=\"noopener noreferrer\">juan@resin.io</a>&gt; Juan Cruz Viotti wrote:<br /><br /><div id=\"fae_1y9nrkr-xcwv15\"><div>Hello</div>\n</div></blockquote>",
-        "text": "Response!\n",
-        "is_draft": false,
-        "error_type": null,
-        "metadata": {},
-        "author": {
-          "_links": {
-            "self": "https://api2.frontapp.com/teammates/tea_grc",
-            "related": {
-              "inboxes": "https://api2.frontapp.com/teammates/tea_grc/inboxes",
-              "conversations": "https://api2.frontapp.com/teammates/tea_grc/conversations"
-            }
-          },
-          "id": "tea_grc",
-          "email": "juan@resin.io",
-          "username": "jviotti",
-          "first_name": "Juan Cruz",
-          "last_name": "Viotti",
-          "is_admin": true,
-          "is_available": true
-        },
-        "recipients": [
-          {
-            "_links": {
-              "related": {
-                "contact": null
-              }
-            },
-            "handle": "test@resin.io",
-            "role": "from"
-          },
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_5ef35"
-              }
-            },
-            "handle": "juan@resin.io",
-            "role": "to"
-          }
-        ],
-        "attachments": []
-      },
       "created_at": 1539210518.211,
       "is_private": false
     },

--- a/test/integration/webhooks/inbound-delete-message/stubs/1/messages-msg-1-y-9-npub.json
+++ b/test/integration/webhooks/inbound-delete-message/stubs/1/messages-msg-1-y-9-npub.json
@@ -1,0 +1,40 @@
+{
+    "_links": {
+      "self": "https://api2.frontapp.com/messages/msg_1y9npub",
+      "related": {
+        "conversation": "https://api2.frontapp.com/conversations/cnv_11she63"
+      }
+    },
+    "id": "msg_1y9npub",
+    "type": "email",
+    "is_inbound": true,
+    "created_at": 1539210518.044,
+    "blurb": " Hello ",
+    "body": "<div>Hello</div>\n",
+    "text": "Hello\n",
+    "is_draft": false,
+    "error_type": null,
+    "metadata": {},
+    "author": null,
+    "recipients": [
+      {
+        "_links": {
+          "related": {
+            "contact": "https://api2.frontapp.com/contacts/crd_5ef35"
+          }
+        },
+        "handle": "juan@resin.io",
+        "role": "from"
+      },
+      {
+        "_links": {
+          "related": {
+            "contact": null
+          }
+        },
+        "handle": "ei8z-resin_io@in.frontapp.com",
+        "role": "to"
+      }
+    ],
+    "attachments": []
+}

--- a/test/integration/webhooks/inbound-delete-message/stubs/5/messages-msg-1-y-9-nrkr.json
+++ b/test/integration/webhooks/inbound-delete-message/stubs/5/messages-msg-1-y-9-nrkr.json
@@ -1,0 +1,55 @@
+{
+    "_links": {
+      "self": "https://api2.frontapp.com/messages/msg_1y9nrkr",
+      "related": {
+        "conversation": "https://api2.frontapp.com/conversations/cnv_11she63"
+      }
+    },
+    "id": "msg_1y9nrkr",
+    "type": "email",
+    "is_inbound": false,
+    "created_at": 1539210552.763,
+    "blurb": "Response! ",
+    "body": "<div>Response!</div><br><div class=\"front-signature fa-uid_1adb5fca3c6ea641296a83c893eddfa6\">—<br />Juan Cruz Viotti,<div>Software Engineer, Resin.io (https://resin.io)</div><div>twt: @resin_io</div></div><br><blockquote type=\"cite\" class=\"front-blockquote\">On Wed, Oct 10, 2018 at 11:28 pm,  &lt;<a href=\"mailto:juan@resin.io\" target=\"_blank\" rel=\"noopener noreferrer\">juan@resin.io</a>&gt; Juan Cruz Viotti wrote:<br /><br /><div id=\"fae_1y9nrkr-xcwv15\"><div>Hello</div>\n</div></blockquote>",
+    "text": "Response!\n",
+    "is_draft": false,
+    "error_type": null,
+    "metadata": {},
+    "author": {
+      "_links": {
+        "self": "https://api2.frontapp.com/teammates/tea_grc",
+        "related": {
+          "inboxes": "https://api2.frontapp.com/teammates/tea_grc/inboxes",
+          "conversations": "https://api2.frontapp.com/teammates/tea_grc/conversations"
+        }
+      },
+      "id": "tea_grc",
+      "email": "juan@resin.io",
+      "username": "jviotti",
+      "first_name": "Juan Cruz",
+      "last_name": "Viotti",
+      "is_admin": true,
+      "is_available": true
+    },
+    "recipients": [
+      {
+        "_links": {
+          "related": {
+            "contact": null
+          }
+        },
+        "handle": "test@resin.io",
+        "role": "from"
+      },
+      {
+        "_links": {
+          "related": {
+            "contact": "https://api2.frontapp.com/contacts/crd_5ef35"
+          }
+        },
+        "handle": "juan@resin.io",
+        "role": "to"
+      }
+    ],
+    "attachments": []
+}

--- a/test/integration/webhooks/inbound-delete-undelete/01.json
+++ b/test/integration/webhooks/inbound-delete-undelete/01.json
@@ -25,7 +25,8 @@
           "followers": "https://api2.frontapp.com/conversations/cnv_11dx1ei/followers",
           "messages": "https://api2.frontapp.com/conversations/cnv_11dx1ei/messages",
           "comments": "https://api2.frontapp.com/conversations/cnv_11dx1ei/comments",
-          "inboxes": "https://api2.frontapp.com/conversations/cnv_11dx1ei/inboxes"
+          "inboxes": "https://api2.frontapp.com/conversations/cnv_11dx1ei/inboxes",
+          "last_message": "https://api2.frontapp.com/messages/msg_1w1glc2"
         }
       },
       "id": "cnv_11dx1ei",
@@ -42,46 +43,6 @@
         "role": "from"
       },
       "tags": [],
-      "last_message": {
-        "_links": {
-          "self": "https://api2.frontapp.com/messages/msg_1w1glc2",
-          "related": {
-            "conversation": "https://api2.frontapp.com/conversations/cnv_11dx1ei"
-          }
-        },
-        "id": "msg_1w1glc2",
-        "type": "email",
-        "is_inbound": true,
-        "created_at": 1539024646.742,
-        "blurb": " ",
-        "body": "<div><br /></div>\n",
-        "text": "\n",
-        "is_draft": false,
-        "error_type": null,
-        "metadata": {},
-        "author": null,
-        "recipients": [
-          {
-            "_links": {
-              "related": {
-                "contact": null
-              }
-            },
-            "handle": "juan@resin.io",
-            "role": "from"
-          },
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_hgkpe"
-              }
-            },
-            "handle": "26ww-resin_io_dev@in.frontapp.com",
-            "role": "to"
-          }
-        ],
-        "attachments": []
-      },
       "created_at": 1539024647.782,
       "is_private": false
     },

--- a/test/integration/webhooks/inbound-delete-undelete/02.json
+++ b/test/integration/webhooks/inbound-delete-undelete/02.json
@@ -25,7 +25,8 @@
           "followers": "https://api2.frontapp.com/conversations/cnv_11dx1ei/followers",
           "messages": "https://api2.frontapp.com/conversations/cnv_11dx1ei/messages",
           "comments": "https://api2.frontapp.com/conversations/cnv_11dx1ei/comments",
-          "inboxes": "https://api2.frontapp.com/conversations/cnv_11dx1ei/inboxes"
+          "inboxes": "https://api2.frontapp.com/conversations/cnv_11dx1ei/inboxes",
+          "last_message": "https://api2.frontapp.com/messages/msg_1w1glc2"
         }
       },
       "id": "cnv_11dx1ei",
@@ -42,46 +43,6 @@
         "role": "from"
       },
       "tags": [],
-      "last_message": {
-        "_links": {
-          "self": "https://api2.frontapp.com/messages/msg_1w1glc2",
-          "related": {
-            "conversation": "https://api2.frontapp.com/conversations/cnv_11dx1ei"
-          }
-        },
-        "id": "msg_1w1glc2",
-        "type": "email",
-        "is_inbound": true,
-        "created_at": 1539024646.742,
-        "blurb": " ",
-        "body": "<div><br /></div>\n",
-        "text": "\n",
-        "is_draft": false,
-        "error_type": null,
-        "metadata": {},
-        "author": null,
-        "recipients": [
-          {
-            "_links": {
-              "related": {
-                "contact": null
-              }
-            },
-            "handle": "juan@resin.io",
-            "role": "from"
-          },
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_hgkpe"
-              }
-            },
-            "handle": "26ww-resin_io_dev@in.frontapp.com",
-            "role": "to"
-          }
-        ],
-        "attachments": []
-      },
       "created_at": 1539024647.782,
       "is_private": false
     },

--- a/test/integration/webhooks/inbound-delete-undelete/03.json
+++ b/test/integration/webhooks/inbound-delete-undelete/03.json
@@ -25,7 +25,8 @@
           "followers": "https://api2.frontapp.com/conversations/cnv_11dx1ei/followers",
           "messages": "https://api2.frontapp.com/conversations/cnv_11dx1ei/messages",
           "comments": "https://api2.frontapp.com/conversations/cnv_11dx1ei/comments",
-          "inboxes": "https://api2.frontapp.com/conversations/cnv_11dx1ei/inboxes"
+          "inboxes": "https://api2.frontapp.com/conversations/cnv_11dx1ei/inboxes",
+          "last_message": "https://api2.frontapp.com/messages/msg_1w1glc2"
         }
       },
       "id": "cnv_11dx1ei",
@@ -42,46 +43,6 @@
         "role": "from"
       },
       "tags": [],
-      "last_message": {
-        "_links": {
-          "self": "https://api2.frontapp.com/messages/msg_1w1glc2",
-          "related": {
-            "conversation": "https://api2.frontapp.com/conversations/cnv_11dx1ei"
-          }
-        },
-        "id": "msg_1w1glc2",
-        "type": "email",
-        "is_inbound": true,
-        "created_at": 1539024646.742,
-        "blurb": " ",
-        "body": "<div><br /></div>\n",
-        "text": "\n",
-        "is_draft": false,
-        "error_type": null,
-        "metadata": {},
-        "author": null,
-        "recipients": [
-          {
-            "_links": {
-              "related": {
-                "contact": null
-              }
-            },
-            "handle": "juan@resin.io",
-            "role": "from"
-          },
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_hgkpe"
-              }
-            },
-            "handle": "26ww-resin_io_dev@in.frontapp.com",
-            "role": "to"
-          }
-        ],
-        "attachments": []
-      },
       "created_at": 1539024647.782,
       "is_private": false
     },

--- a/test/integration/webhooks/inbound-delete-undelete/stubs/1/messages-msg-1-w-1-glc-2.json
+++ b/test/integration/webhooks/inbound-delete-undelete/stubs/1/messages-msg-1-w-1-glc-2.json
@@ -1,0 +1,40 @@
+{
+    "_links": {
+      "self": "https://api2.frontapp.com/messages/msg_1w1glc2",
+      "related": {
+        "conversation": "https://api2.frontapp.com/conversations/cnv_11dx1ei"
+      }
+    },
+    "id": "msg_1w1glc2",
+    "type": "email",
+    "is_inbound": true,
+    "created_at": 1539024646.742,
+    "blurb": " ",
+    "body": "<div><br /></div>\n",
+    "text": "\n",
+    "is_draft": false,
+    "error_type": null,
+    "metadata": {},
+    "author": null,
+    "recipients": [
+      {
+        "_links": {
+          "related": {
+            "contact": null
+          }
+        },
+        "handle": "juan@resin.io",
+        "role": "from"
+      },
+      {
+        "_links": {
+          "related": {
+            "contact": "https://api2.frontapp.com/contacts/crd_hgkpe"
+          }
+        },
+        "handle": "26ww-resin_io_dev@in.frontapp.com",
+        "role": "to"
+      }
+    ],
+    "attachments": []
+}

--- a/test/integration/webhooks/inbound-delete/01.json
+++ b/test/integration/webhooks/inbound-delete/01.json
@@ -25,7 +25,8 @@
           "followers": "https://api2.frontapp.com/conversations/cnv_11dvvhm/followers",
           "messages": "https://api2.frontapp.com/conversations/cnv_11dvvhm/messages",
           "comments": "https://api2.frontapp.com/conversations/cnv_11dvvhm/comments",
-          "inboxes": "https://api2.frontapp.com/conversations/cnv_11dvvhm/inboxes"
+          "inboxes": "https://api2.frontapp.com/conversations/cnv_11dvvhm/inboxes",
+          "last_message": "https://api2.frontapp.com/messages/msg_1w1ewpe"
         }
       },
       "id": "cnv_11dvvhm",
@@ -42,46 +43,6 @@
         "role": "from"
       },
       "tags": [],
-      "last_message": {
-        "_links": {
-          "self": "https://api2.frontapp.com/messages/msg_1w1ewpe",
-          "related": {
-            "conversation": "https://api2.frontapp.com/conversations/cnv_11dvvhm"
-          }
-        },
-        "id": "msg_1w1ewpe",
-        "type": "email",
-        "is_inbound": true,
-        "created_at": 1539023721.954,
-        "blurb": " Hey there ",
-        "body": "<div>Hey there</div>\n",
-        "text": "Hey there\n",
-        "is_draft": false,
-        "error_type": null,
-        "metadata": {},
-        "author": null,
-        "recipients": [
-          {
-            "_links": {
-              "related": {
-                "contact": null
-              }
-            },
-            "handle": "juan@resin.io",
-            "role": "from"
-          },
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_hgkpe"
-              }
-            },
-            "handle": "26ww-resin_io_dev@in.frontapp.com",
-            "role": "to"
-          }
-        ],
-        "attachments": []
-      },
       "created_at": 1539023723.129,
       "is_private": false
     },

--- a/test/integration/webhooks/inbound-delete/02.json
+++ b/test/integration/webhooks/inbound-delete/02.json
@@ -25,7 +25,8 @@
           "followers": "https://api2.frontapp.com/conversations/cnv_11dvvhm/followers",
           "messages": "https://api2.frontapp.com/conversations/cnv_11dvvhm/messages",
           "comments": "https://api2.frontapp.com/conversations/cnv_11dvvhm/comments",
-          "inboxes": "https://api2.frontapp.com/conversations/cnv_11dvvhm/inboxes"
+          "inboxes": "https://api2.frontapp.com/conversations/cnv_11dvvhm/inboxes",
+          "last_message": "https://api2.frontapp.com/messages/msg_1w1ewpe"
         }
       },
       "id": "cnv_11dvvhm",
@@ -42,46 +43,6 @@
         "role": "from"
       },
       "tags": [],
-      "last_message": {
-        "_links": {
-          "self": "https://api2.frontapp.com/messages/msg_1w1ewpe",
-          "related": {
-            "conversation": "https://api2.frontapp.com/conversations/cnv_11dvvhm"
-          }
-        },
-        "id": "msg_1w1ewpe",
-        "type": "email",
-        "is_inbound": true,
-        "created_at": 1539023721.954,
-        "blurb": " Hey there ",
-        "body": "<div>Hey there</div>\n",
-        "text": "Hey there\n",
-        "is_draft": false,
-        "error_type": null,
-        "metadata": {},
-        "author": null,
-        "recipients": [
-          {
-            "_links": {
-              "related": {
-                "contact": null
-              }
-            },
-            "handle": "juan@resin.io",
-            "role": "from"
-          },
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_hgkpe"
-              }
-            },
-            "handle": "26ww-resin_io_dev@in.frontapp.com",
-            "role": "to"
-          }
-        ],
-        "attachments": []
-      },
       "created_at": 1539023723.129,
       "is_private": false
     },

--- a/test/integration/webhooks/inbound-delete/stubs/1/messages-msg-1-w-1-ewpe.json
+++ b/test/integration/webhooks/inbound-delete/stubs/1/messages-msg-1-w-1-ewpe.json
@@ -1,0 +1,40 @@
+{
+    "_links": {
+      "self": "https://api2.frontapp.com/messages/msg_1w1ewpe",
+      "related": {
+        "conversation": "https://api2.frontapp.com/conversations/cnv_11dvvhm"
+      }
+    },
+    "id": "msg_1w1ewpe",
+    "type": "email",
+    "is_inbound": true,
+    "created_at": 1539023721.954,
+    "blurb": " Hey there ",
+    "body": "<div>Hey there</div>\n",
+    "text": "Hey there\n",
+    "is_draft": false,
+    "error_type": null,
+    "metadata": {},
+    "author": null,
+    "recipients": [
+      {
+        "_links": {
+          "related": {
+            "contact": null
+          }
+        },
+        "handle": "juan@resin.io",
+        "role": "from"
+      },
+      {
+        "_links": {
+          "related": {
+            "contact": "https://api2.frontapp.com/contacts/crd_hgkpe"
+          }
+        },
+        "handle": "26ww-resin_io_dev@in.frontapp.com",
+        "role": "to"
+      }
+    ],
+    "attachments": []
+}

--- a/test/integration/webhooks/inbound-inbound-inbound/stubs/1/messages-msg-1-w-1-fdyy.json
+++ b/test/integration/webhooks/inbound-inbound-inbound/stubs/1/messages-msg-1-w-1-fdyy.json
@@ -1,0 +1,40 @@
+{
+    "_links": {
+      "self": "https://api2.frontapp.com/messages/msg_1w1fdyy",
+      "related": {
+        "conversation": "https://api2.frontapp.com/conversations/cnv_11dw6zu"
+      }
+    },
+    "id": "msg_1w1fdyy",
+    "type": "email",
+    "is_inbound": true,
+    "created_at": 1539023985.162,
+    "blurb": " ",
+    "body": "<div><br /></div>\n",
+    "text": "\n",
+    "is_draft": false,
+    "error_type": null,
+    "metadata": {},
+    "author": null,
+    "recipients": [
+      {
+        "_links": {
+          "related": {
+            "contact": null
+          }
+        },
+        "handle": "juan@resin.io",
+        "role": "from"
+      },
+      {
+        "_links": {
+          "related": {
+            "contact": "https://api2.frontapp.com/contacts/crd_hgkpe"
+          }
+        },
+        "handle": "26ww-resin_io_dev@in.frontapp.com",
+        "role": "to"
+      }
+    ],
+    "attachments": []
+}

--- a/test/integration/webhooks/inbound-inbound-inbound/stubs/2/messages-msg-1-w-1-ffia.json
+++ b/test/integration/webhooks/inbound-inbound-inbound/stubs/2/messages-msg-1-w-1-ffia.json
@@ -1,0 +1,40 @@
+{
+    "_links": {
+      "self": "https://api2.frontapp.com/messages/msg_1w1ffia",
+      "related": {
+        "conversation": "https://api2.frontapp.com/conversations/cnv_11dw6zu"
+      }
+    },
+    "id": "msg_1w1ffia",
+    "type": "email",
+    "is_inbound": true,
+    "created_at": 1539024009.52,
+    "blurb": " One On Mon, Oct 8, 2018 at 7:39 PM Juan Cruz Viotti < juan@resin.io > wrote: ",
+    "body": "<div>One</div><br /><div class=\"gmail_quote\"><div>On Mon, Oct 8, 2018 at 7:39 PM Juan Cruz Viotti &lt;<a href=\"mailto:juan@resin.io\" target=\"_blank\" rel=\"noopener noreferrer\">juan@resin.io</a>&gt; wrote:<br /></div><blockquote class=\"gmail_quote front-blockquote\" style=\"margin:0 0 0 .8ex;border-left:1px #ccc solid;padding-left:1ex\"><div><br /></div>\n</blockquote></div>\n",
+    "text": "One\n\nOn Mon, Oct 8, 2018 at 7:39 PM Juan Cruz Viotti <juan@resin.io> wrote:\n\n>\n>\n",
+    "is_draft": false,
+    "error_type": null,
+    "metadata": {},
+    "author": null,
+    "recipients": [
+      {
+        "_links": {
+          "related": {
+            "contact": null
+          }
+        },
+        "handle": "juan@resin.io",
+        "role": "from"
+      },
+      {
+        "_links": {
+          "related": {
+            "contact": "https://api2.frontapp.com/contacts/crd_hgkpe"
+          }
+        },
+        "handle": "26ww-resin_io_dev@in.frontapp.com",
+        "role": "to"
+      }
+    ],
+    "attachments": []
+}

--- a/test/integration/webhooks/inbound-inbound-inbound/stubs/3/messages-msg-1-w-1-ffpe.json
+++ b/test/integration/webhooks/inbound-inbound-inbound/stubs/3/messages-msg-1-w-1-ffpe.json
@@ -1,0 +1,40 @@
+{
+    "_links": {
+      "self": "https://api2.frontapp.com/messages/msg_1w1ffpe",
+      "related": {
+        "conversation": "https://api2.frontapp.com/conversations/cnv_11dw6zu"
+      }
+    },
+    "id": "msg_1w1ffpe",
+    "type": "email",
+    "is_inbound": true,
+    "created_at": 1539024012.958,
+    "blurb": " Two On Mon, Oct 8, 2018 at 7:39 PM Juan Cruz Viotti < juan@resin.io > wrote: One On Mon, Oct 8, 2018 at 7:39 PM Juan Cruz Viotti < juan@resin.io > wrote: ",
+    "body": "<div>Two</div><br /><div class=\"gmail_quote\"><div>On Mon, Oct 8, 2018 at 7:39 PM Juan Cruz Viotti &lt;<a href=\"mailto:juan@resin.io\" target=\"_blank\" rel=\"noopener noreferrer\">juan@resin.io</a>&gt; wrote:<br /></div><blockquote class=\"gmail_quote front-blockquote\" style=\"margin:0 0 0 .8ex;border-left:1px #ccc solid;padding-left:1ex\"><div>One</div><br /><div class=\"gmail_quote\"><div>On Mon, Oct 8, 2018 at 7:39 PM Juan Cruz Viotti &lt;<a href=\"mailto:juan@resin.io\" target=\"_blank\" rel=\"noopener noreferrer\">juan@resin.io</a>&gt; wrote:<br /></div><blockquote class=\"gmail_quote front-blockquote\" style=\"margin:0 0 0 .8ex;border-left:1px #ccc solid;padding-left:1ex\"><div><br /></div>\n</blockquote></div></blockquote></div>\n",
+    "text": "Two\n\nOn Mon, Oct 8, 2018 at 7:39 PM Juan Cruz Viotti <juan@resin.io> wrote:\n\n> One\n>\n> On Mon, Oct 8, 2018 at 7:39 PM Juan Cruz Viotti <juan@resin.io> wrote:\n>\n>>\n>>\n",
+    "is_draft": false,
+    "error_type": null,
+    "metadata": {},
+    "author": null,
+    "recipients": [
+      {
+        "_links": {
+          "related": {
+            "contact": null
+          }
+        },
+        "handle": "juan@resin.io",
+        "role": "from"
+      },
+      {
+        "_links": {
+          "related": {
+            "contact": "https://api2.frontapp.com/contacts/crd_hgkpe"
+          }
+        },
+        "handle": "26ww-resin_io_dev@in.frontapp.com",
+        "role": "to"
+      }
+    ],
+    "attachments": []
+}

--- a/test/integration/webhooks/inbound-message-html/01.json
+++ b/test/integration/webhooks/inbound-message-html/01.json
@@ -25,7 +25,8 @@
           "followers": "https://api2.frontapp.com/conversations/cnv_11sgc1v/followers",
           "messages": "https://api2.frontapp.com/conversations/cnv_11sgc1v/messages",
           "comments": "https://api2.frontapp.com/conversations/cnv_11sgc1v/comments",
-          "inboxes": "https://api2.frontapp.com/conversations/cnv_11sgc1v/inboxes"
+          "inboxes": "https://api2.frontapp.com/conversations/cnv_11sgc1v/inboxes",
+          "last_message": "https://api2.frontapp.com/messages/msg_1y9l8fv"
         }
       },
       "id": "cnv_11sgc1v",
@@ -42,45 +43,6 @@
         "role": "from"
       },
       "tags": [],
-      "last_message": {
-        "_links": {
-          "self": "https://api2.frontapp.com/messages/msg_1y9l8fv",
-          "related": {
-            "conversation": "https://api2.frontapp.com/conversations/cnv_11sgc1v"
-          }
-        },
-        "id": "msg_1y9l8fv",
-        "type": "email",
-        "is_inbound": true,
-        "created_at": 1539209632.817,
-        "blurb": " Hey there! ",
-        "body": "Hey there <foo>!\n",
-        "is_draft": false,
-        "error_type": null,
-        "metadata": {},
-        "author": null,
-        "recipients": [
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_5ef35"
-              }
-            },
-            "handle": "juan@resin.io",
-            "role": "from"
-          },
-          {
-            "_links": {
-              "related": {
-                "contact": null
-              }
-            },
-            "handle": "ei8z-resin_io@in.frontapp.com",
-            "role": "to"
-          }
-        ],
-        "attachments": []
-      },
       "created_at": 1539209633.011,
       "is_private": false
     },

--- a/test/integration/webhooks/inbound-message-html/02.json
+++ b/test/integration/webhooks/inbound-message-html/02.json
@@ -25,7 +25,8 @@
           "followers": "https://api2.frontapp.com/conversations/cnv_11sgc1v/followers",
           "messages": "https://api2.frontapp.com/conversations/cnv_11sgc1v/messages",
           "comments": "https://api2.frontapp.com/conversations/cnv_11sgc1v/comments",
-          "inboxes": "https://api2.frontapp.com/conversations/cnv_11sgc1v/inboxes"
+          "inboxes": "https://api2.frontapp.com/conversations/cnv_11sgc1v/inboxes",
+          "last_message": "https://api2.frontapp.com/messages/msg_1y9l8fv"
         }
       },
       "id": "cnv_11sgc1v",
@@ -57,45 +58,6 @@
         "role": "to"
       },
       "tags": [],
-      "last_message": {
-        "_links": {
-          "self": "https://api2.frontapp.com/messages/msg_1y9l8fv",
-          "related": {
-            "conversation": "https://api2.frontapp.com/conversations/cnv_11sgc1v"
-          }
-        },
-        "id": "msg_1y9l8fv",
-        "type": "email",
-        "is_inbound": true,
-        "created_at": 1539209632.817,
-        "blurb": " Hey there! ",
-        "body": "Hey there <foo>!\n",
-        "is_draft": false,
-        "error_type": null,
-        "metadata": {},
-        "author": null,
-        "recipients": [
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_5ef35"
-              }
-            },
-            "handle": "juan@resin.io",
-            "role": "from"
-          },
-          {
-            "_links": {
-              "related": {
-                "contact": null
-              }
-            },
-            "handle": "ei8z-resin_io@in.frontapp.com",
-            "role": "to"
-          }
-        ],
-        "attachments": []
-      },
       "created_at": 1539209633.011,
       "is_private": false
     },

--- a/test/integration/webhooks/inbound-message-html/03.json
+++ b/test/integration/webhooks/inbound-message-html/03.json
@@ -25,7 +25,8 @@
           "followers": "https://api2.frontapp.com/conversations/cnv_11sgc1v/followers",
           "messages": "https://api2.frontapp.com/conversations/cnv_11sgc1v/messages",
           "comments": "https://api2.frontapp.com/conversations/cnv_11sgc1v/comments",
-          "inboxes": "https://api2.frontapp.com/conversations/cnv_11sgc1v/inboxes"
+          "inboxes": "https://api2.frontapp.com/conversations/cnv_11sgc1v/inboxes",
+          "last_message": "https://api2.frontapp.com/messages/msg_1y9l9g3"
         }
       },
       "id": "cnv_11sgc1v",

--- a/test/integration/webhooks/inbound-message-html/stubs/1/messages-msg-1-y-9-l-8-fv.json
+++ b/test/integration/webhooks/inbound-message-html/stubs/1/messages-msg-1-y-9-l-8-fv.json
@@ -1,0 +1,39 @@
+{
+    "_links": {
+      "self": "https://api2.frontapp.com/messages/msg_1y9l8fv",
+      "related": {
+        "conversation": "https://api2.frontapp.com/conversations/cnv_11sgc1v"
+      }
+    },
+    "id": "msg_1y9l8fv",
+    "type": "email",
+    "is_inbound": true,
+    "created_at": 1539209632.817,
+    "blurb": " Hey there! ",
+    "body": "Hey there <foo>!\n",
+    "is_draft": false,
+    "error_type": null,
+    "metadata": {},
+    "author": null,
+    "recipients": [
+      {
+        "_links": {
+          "related": {
+            "contact": "https://api2.frontapp.com/contacts/crd_5ef35"
+          }
+        },
+        "handle": "juan@resin.io",
+        "role": "from"
+      },
+      {
+        "_links": {
+          "related": {
+            "contact": null
+          }
+        },
+        "handle": "ei8z-resin_io@in.frontapp.com",
+        "role": "to"
+      }
+    ],
+    "attachments": []
+}

--- a/test/integration/webhooks/inbound-message-html/stubs/3/messages-msg-1-y-9-l-9-g-3.json
+++ b/test/integration/webhooks/inbound-message-html/stubs/3/messages-msg-1-y-9-l-9-g-3.json
@@ -1,0 +1,55 @@
+{
+    "_links": {
+      "self": "https://api2.frontapp.com/messages/msg_1y9l9g3",
+      "related": {
+        "conversation": "https://api2.frontapp.com/conversations/cnv_11sgc1v"
+      }
+    },
+    "id": "msg_1y9l9g3",
+    "type": "email",
+    "is_inbound": false,
+    "created_at": 1539209658.632,
+    "blurb": "Response! ",
+    "body": "<div>Response!</div><br><div class=\"front-signature fa-uid_a8aee144305bcb9048143583437fe7f7\">—<br />Juan Cruz Viotti,<div>Software Engineer, Resin.io (https://resin.io)</div><div>twt: @resin_io</div></div><br><blockquote type=\"cite\" class=\"front-blockquote\">On Wed, Oct 10, 2018 at 11:13 pm,  &lt;<a href=\"mailto:juan@resin.io\" target=\"_blank\" rel=\"noopener noreferrer\">juan@resin.io</a>&gt; Juan Cruz Viotti wrote:<br /><br /><div id=\"fae_1y9l9g3b7xo8r\"><div>Hey there!</div>\n</div></blockquote>",
+    "text": "Response!\n",
+    "is_draft": false,
+    "error_type": null,
+    "metadata": {},
+    "author": {
+      "_links": {
+        "self": "https://api2.frontapp.com/teammates/tea_grc",
+        "related": {
+          "inboxes": "https://api2.frontapp.com/teammates/tea_grc/inboxes",
+          "conversations": "https://api2.frontapp.com/teammates/tea_grc/conversations"
+        }
+      },
+      "id": "tea_grc",
+      "email": "juan@resin.io",
+      "username": "jviotti",
+      "first_name": "Juan Cruz",
+      "last_name": "Viotti",
+      "is_admin": true,
+      "is_available": true
+    },
+    "recipients": [
+      {
+        "_links": {
+          "related": {
+            "contact": null
+          }
+        },
+        "handle": "test@resin.io",
+        "role": "from"
+      },
+      {
+        "_links": {
+          "related": {
+            "contact": "https://api2.frontapp.com/contacts/crd_5ef35"
+          }
+        },
+        "handle": "juan@resin.io",
+        "role": "to"
+      }
+    ],
+    "attachments": []
+}

--- a/test/integration/webhooks/inbound-message-multiple-inboxes/01.json
+++ b/test/integration/webhooks/inbound-message-multiple-inboxes/01.json
@@ -25,7 +25,8 @@
           "followers": "https://api2.frontapp.com/conversations/cnv_11sgc1v/followers",
           "messages": "https://api2.frontapp.com/conversations/cnv_11sgc1v/messages",
           "comments": "https://api2.frontapp.com/conversations/cnv_11sgc1v/comments",
-          "inboxes": "https://api2.frontapp.com/conversations/cnv_11sgc1v/inboxes"
+          "inboxes": "https://api2.frontapp.com/conversations/cnv_11sgc1v/inboxes",
+          "last_message": "https://api2.frontapp.com/messages/msg_1y9l8fv"
         }
       },
       "id": "cnv_11sgc1v",
@@ -42,46 +43,6 @@
         "role": "from"
       },
       "tags": [],
-      "last_message": {
-        "_links": {
-          "self": "https://api2.frontapp.com/messages/msg_1y9l8fv",
-          "related": {
-            "conversation": "https://api2.frontapp.com/conversations/cnv_11sgc1v"
-          }
-        },
-        "id": "msg_1y9l8fv",
-        "type": "email",
-        "is_inbound": true,
-        "created_at": 1539209632.817,
-        "blurb": " Hey there! ",
-        "body": "<div>Hey there!</div>\n",
-        "text": "Hey there!\n",
-        "is_draft": false,
-        "error_type": null,
-        "metadata": {},
-        "author": null,
-        "recipients": [
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_5ef35"
-              }
-            },
-            "handle": "juan@resin.io",
-            "role": "from"
-          },
-          {
-            "_links": {
-              "related": {
-                "contact": null
-              }
-            },
-            "handle": "ei8z-resin_io@in.frontapp.com",
-            "role": "to"
-          }
-        ],
-        "attachments": []
-      },
       "created_at": 1539209633.011,
       "is_private": false
     },

--- a/test/integration/webhooks/inbound-message-multiple-inboxes/02.json
+++ b/test/integration/webhooks/inbound-message-multiple-inboxes/02.json
@@ -25,7 +25,8 @@
           "followers": "https://api2.frontapp.com/conversations/cnv_11sgc1v/followers",
           "messages": "https://api2.frontapp.com/conversations/cnv_11sgc1v/messages",
           "comments": "https://api2.frontapp.com/conversations/cnv_11sgc1v/comments",
-          "inboxes": "https://api2.frontapp.com/conversations/cnv_11sgc1v/inboxes"
+          "inboxes": "https://api2.frontapp.com/conversations/cnv_11sgc1v/inboxes",
+          "last_message": "https://api2.frontapp.com/messages/msg_1y9l8fv"
         }
       },
       "id": "cnv_11sgc1v",
@@ -57,46 +58,6 @@
         "role": "to"
       },
       "tags": [],
-      "last_message": {
-        "_links": {
-          "self": "https://api2.frontapp.com/messages/msg_1y9l8fv",
-          "related": {
-            "conversation": "https://api2.frontapp.com/conversations/cnv_11sgc1v"
-          }
-        },
-        "id": "msg_1y9l8fv",
-        "type": "email",
-        "is_inbound": true,
-        "created_at": 1539209632.817,
-        "blurb": " Hey there! ",
-        "body": "<div>Hey there!</div>\n",
-        "text": "Hey there!\n",
-        "is_draft": false,
-        "error_type": null,
-        "metadata": {},
-        "author": null,
-        "recipients": [
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_5ef35"
-              }
-            },
-            "handle": "juan@resin.io",
-            "role": "from"
-          },
-          {
-            "_links": {
-              "related": {
-                "contact": null
-              }
-            },
-            "handle": "ei8z-resin_io@in.frontapp.com",
-            "role": "to"
-          }
-        ],
-        "attachments": []
-      },
       "created_at": 1539209633.011,
       "is_private": false
     },

--- a/test/integration/webhooks/inbound-message-multiple-inboxes/03.json
+++ b/test/integration/webhooks/inbound-message-multiple-inboxes/03.json
@@ -25,7 +25,8 @@
           "followers": "https://api2.frontapp.com/conversations/cnv_11sgc1v/followers",
           "messages": "https://api2.frontapp.com/conversations/cnv_11sgc1v/messages",
           "comments": "https://api2.frontapp.com/conversations/cnv_11sgc1v/comments",
-          "inboxes": "https://api2.frontapp.com/conversations/cnv_11sgc1v/inboxes"
+          "inboxes": "https://api2.frontapp.com/conversations/cnv_11sgc1v/inboxes",
+          "last_message": "https://api2.frontapp.com/messages/msg_1y9l9g3"
         }
       },
       "id": "cnv_11sgc1v",
@@ -57,61 +58,6 @@
         "role": "to"
       },
       "tags": [],
-      "last_message": {
-        "_links": {
-          "self": "https://api2.frontapp.com/messages/msg_1y9l9g3",
-          "related": {
-            "conversation": "https://api2.frontapp.com/conversations/cnv_11sgc1v"
-          }
-        },
-        "id": "msg_1y9l9g3",
-        "type": "email",
-        "is_inbound": false,
-        "created_at": 1539209658.632,
-        "blurb": "Response! ",
-        "body": "<div>Response!</div><br><div class=\"front-signature fa-uid_a8aee144305bcb9048143583437fe7f7\">—<br />Juan Cruz Viotti,<div>Software Engineer, Resin.io (https://resin.io)</div><div>twt: @resin_io</div></div><br><blockquote type=\"cite\" class=\"front-blockquote\">On Wed, Oct 10, 2018 at 11:13 pm,  &lt;<a href=\"mailto:juan@resin.io\" target=\"_blank\" rel=\"noopener noreferrer\">juan@resin.io</a>&gt; Juan Cruz Viotti wrote:<br /><br /><div id=\"fae_1y9l9g3b7xo8r\"><div>Hey there!</div>\n</div></blockquote>",
-        "text": "Response!\n",
-        "is_draft": false,
-        "error_type": null,
-        "metadata": {},
-        "author": {
-          "_links": {
-            "self": "https://api2.frontapp.com/teammates/tea_grc",
-            "related": {
-              "inboxes": "https://api2.frontapp.com/teammates/tea_grc/inboxes",
-              "conversations": "https://api2.frontapp.com/teammates/tea_grc/conversations"
-            }
-          },
-          "id": "tea_grc",
-          "email": "juan@resin.io",
-          "username": "jviotti",
-          "first_name": "Juan Cruz",
-          "last_name": "Viotti",
-          "is_admin": true,
-          "is_available": true
-        },
-        "recipients": [
-          {
-            "_links": {
-              "related": {
-                "contact": null
-              }
-            },
-            "handle": "test@resin.io",
-            "role": "from"
-          },
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_5ef35"
-              }
-            },
-            "handle": "juan@resin.io",
-            "role": "to"
-          }
-        ],
-        "attachments": []
-      },
       "created_at": 1539209633.011,
       "is_private": false
     },

--- a/test/integration/webhooks/inbound-message-multiple-inboxes/stubs/1/messages-msg-1-y-9-l-8-fv.json
+++ b/test/integration/webhooks/inbound-message-multiple-inboxes/stubs/1/messages-msg-1-y-9-l-8-fv.json
@@ -1,0 +1,40 @@
+{
+    "_links": {
+      "self": "https://api2.frontapp.com/messages/msg_1y9l8fv",
+      "related": {
+        "conversation": "https://api2.frontapp.com/conversations/cnv_11sgc1v"
+      }
+    },
+    "id": "msg_1y9l8fv",
+    "type": "email",
+    "is_inbound": true,
+    "created_at": 1539209632.817,
+    "blurb": " Hey there! ",
+    "body": "<div>Hey there!</div>\n",
+    "text": "Hey there!\n",
+    "is_draft": false,
+    "error_type": null,
+    "metadata": {},
+    "author": null,
+    "recipients": [
+      {
+        "_links": {
+          "related": {
+            "contact": "https://api2.frontapp.com/contacts/crd_5ef35"
+          }
+        },
+        "handle": "juan@resin.io",
+        "role": "from"
+      },
+      {
+        "_links": {
+          "related": {
+            "contact": null
+          }
+        },
+        "handle": "ei8z-resin_io@in.frontapp.com",
+        "role": "to"
+      }
+    ],
+    "attachments": []
+}

--- a/test/integration/webhooks/inbound-message-multiple-inboxes/stubs/1/messages-msg-1-y-9-l-9-g-3.json
+++ b/test/integration/webhooks/inbound-message-multiple-inboxes/stubs/1/messages-msg-1-y-9-l-9-g-3.json
@@ -1,0 +1,40 @@
+{
+    "_links": {
+      "self": "https://api2.frontapp.com/messages/msg_1y9l8fv",
+      "related": {
+        "conversation": "https://api2.frontapp.com/conversations/cnv_11sgc1v"
+      }
+    },
+    "id": "msg_1y9l8fv",
+    "type": "email",
+    "is_inbound": true,
+    "created_at": 1539209632.817,
+    "blurb": " Hey there! ",
+    "body": "<div>Hey there!</div>\n",
+    "text": "Hey there!\n",
+    "is_draft": false,
+    "error_type": null,
+    "metadata": {},
+    "author": null,
+    "recipients": [
+      {
+        "_links": {
+          "related": {
+            "contact": "https://api2.frontapp.com/contacts/crd_5ef35"
+          }
+        },
+        "handle": "juan@resin.io",
+        "role": "from"
+      },
+      {
+        "_links": {
+          "related": {
+            "contact": null
+          }
+        },
+        "handle": "ei8z-resin_io@in.frontapp.com",
+        "role": "to"
+      }
+    ],
+    "attachments": []
+}

--- a/test/integration/webhooks/inbound-message/01.json
+++ b/test/integration/webhooks/inbound-message/01.json
@@ -25,7 +25,8 @@
           "followers": "https://api2.frontapp.com/conversations/cnv_11sgc1v/followers",
           "messages": "https://api2.frontapp.com/conversations/cnv_11sgc1v/messages",
           "comments": "https://api2.frontapp.com/conversations/cnv_11sgc1v/comments",
-          "inboxes": "https://api2.frontapp.com/conversations/cnv_11sgc1v/inboxes"
+          "inboxes": "https://api2.frontapp.com/conversations/cnv_11sgc1v/inboxes",
+          "last_message": "https://api2.frontapp.com/messages/msg_1y9l8fv"
         }
       },
       "id": "cnv_11sgc1v",
@@ -42,46 +43,6 @@
         "role": "from"
       },
       "tags": [],
-      "last_message": {
-        "_links": {
-          "self": "https://api2.frontapp.com/messages/msg_1y9l8fv",
-          "related": {
-            "conversation": "https://api2.frontapp.com/conversations/cnv_11sgc1v"
-          }
-        },
-        "id": "msg_1y9l8fv",
-        "type": "email",
-        "is_inbound": true,
-        "created_at": 1539209632.817,
-        "blurb": " Hey there @foo!! ",
-        "body": "<div>Hey there @foo!!</div>\n",
-        "text": "Hey there @foo!!\n",
-        "is_draft": false,
-        "error_type": null,
-        "metadata": {},
-        "author": null,
-        "recipients": [
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_5ef35"
-              }
-            },
-            "handle": "juan@resin.io",
-            "role": "from"
-          },
-          {
-            "_links": {
-              "related": {
-                "contact": null
-              }
-            },
-            "handle": "ei8z-resin_io@in.frontapp.com",
-            "role": "to"
-          }
-        ],
-        "attachments": []
-      },
       "created_at": 1539209633.011,
       "is_private": false
     },

--- a/test/integration/webhooks/inbound-message/02.json
+++ b/test/integration/webhooks/inbound-message/02.json
@@ -25,7 +25,8 @@
           "followers": "https://api2.frontapp.com/conversations/cnv_11sgc1v/followers",
           "messages": "https://api2.frontapp.com/conversations/cnv_11sgc1v/messages",
           "comments": "https://api2.frontapp.com/conversations/cnv_11sgc1v/comments",
-          "inboxes": "https://api2.frontapp.com/conversations/cnv_11sgc1v/inboxes"
+          "inboxes": "https://api2.frontapp.com/conversations/cnv_11sgc1v/inboxes",
+          "last_message": "https://api2.frontapp.com/messages/msg_1y9l8fv"
         }
       },
       "id": "cnv_11sgc1v",
@@ -57,46 +58,6 @@
         "role": "to"
       },
       "tags": [],
-      "last_message": {
-        "_links": {
-          "self": "https://api2.frontapp.com/messages/msg_1y9l8fv",
-          "related": {
-            "conversation": "https://api2.frontapp.com/conversations/cnv_11sgc1v"
-          }
-        },
-        "id": "msg_1y9l8fv",
-        "type": "email",
-        "is_inbound": true,
-        "created_at": 1539209632.817,
-        "blurb": " Hey there @foo!! ",
-        "body": "<div>Hey there @foo!!</div>\n",
-        "text": "Hey there @foo!!\n",
-        "is_draft": false,
-        "error_type": null,
-        "metadata": {},
-        "author": null,
-        "recipients": [
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_5ef35"
-              }
-            },
-            "handle": "juan@resin.io",
-            "role": "from"
-          },
-          {
-            "_links": {
-              "related": {
-                "contact": null
-              }
-            },
-            "handle": "ei8z-resin_io@in.frontapp.com",
-            "role": "to"
-          }
-        ],
-        "attachments": []
-      },
       "created_at": 1539209633.011,
       "is_private": false
     },

--- a/test/integration/webhooks/inbound-message/03.json
+++ b/test/integration/webhooks/inbound-message/03.json
@@ -25,7 +25,8 @@
           "followers": "https://api2.frontapp.com/conversations/cnv_11sgc1v/followers",
           "messages": "https://api2.frontapp.com/conversations/cnv_11sgc1v/messages",
           "comments": "https://api2.frontapp.com/conversations/cnv_11sgc1v/comments",
-          "inboxes": "https://api2.frontapp.com/conversations/cnv_11sgc1v/inboxes"
+          "inboxes": "https://api2.frontapp.com/conversations/cnv_11sgc1v/inboxes",
+          "last_message": "https://api2.frontapp.com/messages/msg_1y9l9g3"
         }
       },
       "id": "cnv_11sgc1v",
@@ -57,61 +58,6 @@
         "role": "to"
       },
       "tags": [],
-      "last_message": {
-        "_links": {
-          "self": "https://api2.frontapp.com/messages/msg_1y9l9g3",
-          "related": {
-            "conversation": "https://api2.frontapp.com/conversations/cnv_11sgc1v"
-          }
-        },
-        "id": "msg_1y9l9g3",
-        "type": "email",
-        "is_inbound": false,
-        "created_at": 1539209658.632,
-        "blurb": "Response! ",
-        "body": "<div>Response!</div><br><div class=\"front-signature fa-uid_a8aee144305bcb9048143583437fe7f7\">—<br />Juan Cruz Viotti,<div>Software Engineer, Resin.io (https://resin.io)</div><div>twt: @resin_io</div></div><br><blockquote type=\"cite\" class=\"front-blockquote\">On Wed, Oct 10, 2018 at 11:13 pm,  &lt;<a href=\"mailto:juan@resin.io\" target=\"_blank\" rel=\"noopener noreferrer\">juan@resin.io</a>&gt; Juan Cruz Viotti wrote:<br /><br /><div id=\"fae_1y9l9g3b7xo8r\"><div>Hey there @foo!!</div>\n</div></blockquote>",
-        "text": "Response!\n",
-        "is_draft": false,
-        "error_type": null,
-        "metadata": {},
-        "author": {
-          "_links": {
-            "self": "https://api2.frontapp.com/teammates/tea_grc",
-            "related": {
-              "inboxes": "https://api2.frontapp.com/teammates/tea_grc/inboxes",
-              "conversations": "https://api2.frontapp.com/teammates/tea_grc/conversations"
-            }
-          },
-          "id": "tea_grc",
-          "email": "juan@resin.io",
-          "username": "jviotti",
-          "first_name": "Juan Cruz",
-          "last_name": "Viotti",
-          "is_admin": true,
-          "is_available": true
-        },
-        "recipients": [
-          {
-            "_links": {
-              "related": {
-                "contact": null
-              }
-            },
-            "handle": "test@resin.io",
-            "role": "from"
-          },
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_5ef35"
-              }
-            },
-            "handle": "juan@resin.io",
-            "role": "to"
-          }
-        ],
-        "attachments": []
-      },
       "created_at": 1539209633.011,
       "is_private": false
     },

--- a/test/integration/webhooks/inbound-message/stubs/1/messages-msg-1-y-9-l-8-fv.json
+++ b/test/integration/webhooks/inbound-message/stubs/1/messages-msg-1-y-9-l-8-fv.json
@@ -1,0 +1,40 @@
+{
+    "_links": {
+      "self": "https://api2.frontapp.com/messages/msg_1y9l8fv",
+      "related": {
+        "conversation": "https://api2.frontapp.com/conversations/cnv_11sgc1v"
+      }
+    },
+    "id": "msg_1y9l8fv",
+    "type": "email",
+    "is_inbound": true,
+    "created_at": 1539209632.817,
+    "blurb": " Hey there @foo!! ",
+    "body": "<div>Hey there @foo!!</div>\n",
+    "text": "Hey there @foo!!\n",
+    "is_draft": false,
+    "error_type": null,
+    "metadata": {},
+    "author": null,
+    "recipients": [
+      {
+        "_links": {
+          "related": {
+            "contact": "https://api2.frontapp.com/contacts/crd_5ef35"
+          }
+        },
+        "handle": "juan@resin.io",
+        "role": "from"
+      },
+      {
+        "_links": {
+          "related": {
+            "contact": null
+          }
+        },
+        "handle": "ei8z-resin_io@in.frontapp.com",
+        "role": "to"
+      }
+    ],
+    "attachments": []
+}

--- a/test/integration/webhooks/inbound-message/stubs/3/messages-msg-1-y-9-l-9-g-3.json
+++ b/test/integration/webhooks/inbound-message/stubs/3/messages-msg-1-y-9-l-9-g-3.json
@@ -1,0 +1,55 @@
+{
+    "_links": {
+      "self": "https://api2.frontapp.com/messages/msg_1y9l9g3",
+      "related": {
+        "conversation": "https://api2.frontapp.com/conversations/cnv_11sgc1v"
+      }
+    },
+    "id": "msg_1y9l9g3",
+    "type": "email",
+    "is_inbound": false,
+    "created_at": 1539209658.632,
+    "blurb": "Response! ",
+    "body": "<div>Response!</div><br><div class=\"front-signature fa-uid_a8aee144305bcb9048143583437fe7f7\">—<br />Juan Cruz Viotti,<div>Software Engineer, Resin.io (https://resin.io)</div><div>twt: @resin_io</div></div><br><blockquote type=\"cite\" class=\"front-blockquote\">On Wed, Oct 10, 2018 at 11:13 pm,  &lt;<a href=\"mailto:juan@resin.io\" target=\"_blank\" rel=\"noopener noreferrer\">juan@resin.io</a>&gt; Juan Cruz Viotti wrote:<br /><br /><div id=\"fae_1y9l9g3b7xo8r\"><div>Hey there @foo!!</div>\n</div></blockquote>",
+    "text": "Response!\n",
+    "is_draft": false,
+    "error_type": null,
+    "metadata": {},
+    "author": {
+      "_links": {
+        "self": "https://api2.frontapp.com/teammates/tea_grc",
+        "related": {
+          "inboxes": "https://api2.frontapp.com/teammates/tea_grc/inboxes",
+          "conversations": "https://api2.frontapp.com/teammates/tea_grc/conversations"
+        }
+      },
+      "id": "tea_grc",
+      "email": "juan@resin.io",
+      "username": "jviotti",
+      "first_name": "Juan Cruz",
+      "last_name": "Viotti",
+      "is_admin": true,
+      "is_available": true
+    },
+    "recipients": [
+      {
+        "_links": {
+          "related": {
+            "contact": null
+          }
+        },
+        "handle": "test@resin.io",
+        "role": "from"
+      },
+      {
+        "_links": {
+          "related": {
+            "contact": "https://api2.frontapp.com/contacts/crd_5ef35"
+          }
+        },
+        "handle": "juan@resin.io",
+        "role": "to"
+      }
+    ],
+    "attachments": []
+}

--- a/test/integration/webhooks/inbound-no-body/01.json
+++ b/test/integration/webhooks/inbound-no-body/01.json
@@ -25,7 +25,8 @@
           "followers": "https://api2.frontapp.com/conversations/cnv_11dw4gy/followers",
           "messages": "https://api2.frontapp.com/conversations/cnv_11dw4gy/messages",
           "comments": "https://api2.frontapp.com/conversations/cnv_11dw4gy/comments",
-          "inboxes": "https://api2.frontapp.com/conversations/cnv_11dw4gy/inboxes"
+          "inboxes": "https://api2.frontapp.com/conversations/cnv_11dw4gy/inboxes",
+          "last_message": "https://api2.frontapp.com/messages/msg_1w1fa7m"
         }
       },
       "id": "cnv_11dw4gy",
@@ -42,46 +43,6 @@
         "role": "from"
       },
       "tags": [],
-      "last_message": {
-        "_links": {
-          "self": "https://api2.frontapp.com/messages/msg_1w1fa7m",
-          "related": {
-            "conversation": "https://api2.frontapp.com/conversations/cnv_11dw4gy"
-          }
-        },
-        "id": "msg_1w1fa7m",
-        "type": "email",
-        "is_inbound": true,
-        "created_at": 1539023930.061,
-        "blurb": " ",
-        "body": "<div><br /></div>\n",
-        "text": "\n",
-        "is_draft": false,
-        "error_type": null,
-        "metadata": {},
-        "author": null,
-        "recipients": [
-          {
-            "_links": {
-              "related": {
-                "contact": null
-              }
-            },
-            "handle": "juan@resin.io",
-            "role": "from"
-          },
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_hgkpe"
-              }
-            },
-            "handle": "26ww-resin_io_dev@in.frontapp.com",
-            "role": "to"
-          }
-        ],
-        "attachments": []
-      },
       "created_at": 1539023931.127,
       "is_private": false
     },

--- a/test/integration/webhooks/inbound-no-body/stubs/1/messages-msg-1-w-1-fa-7-m.json
+++ b/test/integration/webhooks/inbound-no-body/stubs/1/messages-msg-1-w-1-fa-7-m.json
@@ -1,0 +1,40 @@
+{
+    "_links": {
+      "self": "https://api2.frontapp.com/messages/msg_1w1fa7m",
+      "related": {
+        "conversation": "https://api2.frontapp.com/conversations/cnv_11dw4gy"
+      }
+    },
+    "id": "msg_1w1fa7m",
+    "type": "email",
+    "is_inbound": true,
+    "created_at": 1539023930.061,
+    "blurb": " ",
+    "body": "<div><br /></div>\n",
+    "text": "\n",
+    "is_draft": false,
+    "error_type": null,
+    "metadata": {},
+    "author": null,
+    "recipients": [
+      {
+        "_links": {
+          "related": {
+            "contact": null
+          }
+        },
+        "handle": "juan@resin.io",
+        "role": "from"
+      },
+      {
+        "_links": {
+          "related": {
+            "contact": "https://api2.frontapp.com/contacts/crd_hgkpe"
+          }
+        },
+        "handle": "26ww-resin_io_dev@in.frontapp.com",
+        "role": "to"
+      }
+    ],
+    "attachments": []
+}

--- a/test/integration/webhooks/inbound-snooze-cancel/01.json
+++ b/test/integration/webhooks/inbound-snooze-cancel/01.json
@@ -25,7 +25,8 @@
           "followers": "https://api2.frontapp.com/conversations/cnv_11sddxf/followers",
           "messages": "https://api2.frontapp.com/conversations/cnv_11sddxf/messages",
           "comments": "https://api2.frontapp.com/conversations/cnv_11sddxf/comments",
-          "inboxes": "https://api2.frontapp.com/conversations/cnv_11sddxf/inboxes"
+          "inboxes": "https://api2.frontapp.com/conversations/cnv_11sddxf/inboxes",
+          "last_message": "https://api2.frontapp.com/messages/msg_1y9e66r"
         }
       },
       "id": "cnv_11sddxf",
@@ -42,46 +43,6 @@
         "role": "from"
       },
       "tags": [],
-      "last_message": {
-        "_links": {
-          "self": "https://api2.frontapp.com/messages/msg_1y9e66r",
-          "related": {
-            "conversation": "https://api2.frontapp.com/conversations/cnv_11sddxf"
-          }
-        },
-        "id": "msg_1y9e66r",
-        "type": "email",
-        "is_inbound": true,
-        "created_at": 1539207260.263,
-        "blurb": " ",
-        "body": "<div><br /></div>\n",
-        "text": "\n",
-        "is_draft": false,
-        "error_type": null,
-        "metadata": {},
-        "author": null,
-        "recipients": [
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_5ef35"
-              }
-            },
-            "handle": "juan@resin.io",
-            "role": "from"
-          },
-          {
-            "_links": {
-              "related": {
-                "contact": null
-              }
-            },
-            "handle": "ei8z-resin_io@in.frontapp.com",
-            "role": "to"
-          }
-        ],
-        "attachments": []
-      },
       "created_at": 1539207260.45,
       "is_private": false
     },

--- a/test/integration/webhooks/inbound-snooze-cancel/02.json
+++ b/test/integration/webhooks/inbound-snooze-cancel/02.json
@@ -25,7 +25,8 @@
           "followers": "https://api2.frontapp.com/conversations/cnv_11sddxf/followers",
           "messages": "https://api2.frontapp.com/conversations/cnv_11sddxf/messages",
           "comments": "https://api2.frontapp.com/conversations/cnv_11sddxf/comments",
-          "inboxes": "https://api2.frontapp.com/conversations/cnv_11sddxf/inboxes"
+          "inboxes": "https://api2.frontapp.com/conversations/cnv_11sddxf/inboxes",
+          "last_message": "https://api2.frontapp.com/messages/msg_1y9e66r"
         }
       },
       "id": "cnv_11sddxf",
@@ -42,46 +43,6 @@
         "role": "from"
       },
       "tags": [],
-      "last_message": {
-        "_links": {
-          "self": "https://api2.frontapp.com/messages/msg_1y9e66r",
-          "related": {
-            "conversation": "https://api2.frontapp.com/conversations/cnv_11sddxf"
-          }
-        },
-        "id": "msg_1y9e66r",
-        "type": "email",
-        "is_inbound": true,
-        "created_at": 1539207260.263,
-        "blurb": " ",
-        "body": "<div><br /></div>\n",
-        "text": "\n",
-        "is_draft": false,
-        "error_type": null,
-        "metadata": {},
-        "author": null,
-        "recipients": [
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_5ef35"
-              }
-            },
-            "handle": "juan@resin.io",
-            "role": "from"
-          },
-          {
-            "_links": {
-              "related": {
-                "contact": null
-              }
-            },
-            "handle": "ei8z-resin_io@in.frontapp.com",
-            "role": "to"
-          }
-        ],
-        "attachments": []
-      },
       "created_at": 1539207260.45,
       "is_private": false
     },

--- a/test/integration/webhooks/inbound-snooze-cancel/03.json
+++ b/test/integration/webhooks/inbound-snooze-cancel/03.json
@@ -25,7 +25,8 @@
           "followers": "https://api2.frontapp.com/conversations/cnv_11sddxf/followers",
           "messages": "https://api2.frontapp.com/conversations/cnv_11sddxf/messages",
           "comments": "https://api2.frontapp.com/conversations/cnv_11sddxf/comments",
-          "inboxes": "https://api2.frontapp.com/conversations/cnv_11sddxf/inboxes"
+          "inboxes": "https://api2.frontapp.com/conversations/cnv_11sddxf/inboxes",
+          "last_message": "https://api2.frontapp.com/messages/msg_1y9e66r"
         }
       },
       "id": "cnv_11sddxf",
@@ -42,46 +43,6 @@
         "role": "from"
       },
       "tags": [],
-      "last_message": {
-        "_links": {
-          "self": "https://api2.frontapp.com/messages/msg_1y9e66r",
-          "related": {
-            "conversation": "https://api2.frontapp.com/conversations/cnv_11sddxf"
-          }
-        },
-        "id": "msg_1y9e66r",
-        "type": "email",
-        "is_inbound": true,
-        "created_at": 1539207260.263,
-        "blurb": " ",
-        "body": "<div><br /></div>\n",
-        "text": "\n",
-        "is_draft": false,
-        "error_type": null,
-        "metadata": {},
-        "author": null,
-        "recipients": [
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_5ef35"
-              }
-            },
-            "handle": "juan@resin.io",
-            "role": "from"
-          },
-          {
-            "_links": {
-              "related": {
-                "contact": null
-              }
-            },
-            "handle": "ei8z-resin_io@in.frontapp.com",
-            "role": "to"
-          }
-        ],
-        "attachments": []
-      },
       "created_at": 1539207260.45,
       "is_private": false
     },

--- a/test/integration/webhooks/inbound-snooze-cancel/stubs/1/messages-msg-1-y-9-e-66-r.json
+++ b/test/integration/webhooks/inbound-snooze-cancel/stubs/1/messages-msg-1-y-9-e-66-r.json
@@ -1,0 +1,40 @@
+{
+    "_links": {
+      "self": "https://api2.frontapp.com/messages/msg_1y9e66r",
+      "related": {
+        "conversation": "https://api2.frontapp.com/conversations/cnv_11sddxf"
+      }
+    },
+    "id": "msg_1y9e66r",
+    "type": "email",
+    "is_inbound": true,
+    "created_at": 1539207260.263,
+    "blurb": " ",
+    "body": "<div><br /></div>\n",
+    "text": "\n",
+    "is_draft": false,
+    "error_type": null,
+    "metadata": {},
+    "author": null,
+    "recipients": [
+      {
+        "_links": {
+          "related": {
+            "contact": "https://api2.frontapp.com/contacts/crd_5ef35"
+          }
+        },
+        "handle": "juan@resin.io",
+        "role": "from"
+      },
+      {
+        "_links": {
+          "related": {
+            "contact": null
+          }
+        },
+        "handle": "ei8z-resin_io@in.frontapp.com",
+        "role": "to"
+      }
+    ],
+    "attachments": []
+}

--- a/test/integration/webhooks/inbound-snooze/01.json
+++ b/test/integration/webhooks/inbound-snooze/01.json
@@ -25,7 +25,8 @@
           "followers": "https://api2.frontapp.com/conversations/cnv_11sdgij/followers",
           "messages": "https://api2.frontapp.com/conversations/cnv_11sdgij/messages",
           "comments": "https://api2.frontapp.com/conversations/cnv_11sdgij/comments",
-          "inboxes": "https://api2.frontapp.com/conversations/cnv_11sdgij/inboxes"
+          "inboxes": "https://api2.frontapp.com/conversations/cnv_11sdgij/inboxes",
+          "last_message": "https://api2.frontapp.com/messages/msg_1y9ecqj"
         }
       },
       "id": "cnv_11sdgij",
@@ -42,46 +43,6 @@
         "role": "from"
       },
       "tags": [],
-      "last_message": {
-        "_links": {
-          "self": "https://api2.frontapp.com/messages/msg_1y9ecqj",
-          "related": {
-            "conversation": "https://api2.frontapp.com/conversations/cnv_11sdgij"
-          }
-        },
-        "id": "msg_1y9ecqj",
-        "type": "email",
-        "is_inbound": true,
-        "created_at": 1539207321.998,
-        "blurb": " ",
-        "body": "<div><br /></div>\n",
-        "text": "\n",
-        "is_draft": false,
-        "error_type": null,
-        "metadata": {},
-        "author": null,
-        "recipients": [
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_5ef35"
-              }
-            },
-            "handle": "juan@resin.io",
-            "role": "from"
-          },
-          {
-            "_links": {
-              "related": {
-                "contact": null
-              }
-            },
-            "handle": "ei8z-resin_io@in.frontapp.com",
-            "role": "to"
-          }
-        ],
-        "attachments": []
-      },
       "created_at": 1539207322.171,
       "is_private": false
     },

--- a/test/integration/webhooks/inbound-snooze/02.json
+++ b/test/integration/webhooks/inbound-snooze/02.json
@@ -25,7 +25,8 @@
           "followers": "https://api2.frontapp.com/conversations/cnv_11sdgij/followers",
           "messages": "https://api2.frontapp.com/conversations/cnv_11sdgij/messages",
           "comments": "https://api2.frontapp.com/conversations/cnv_11sdgij/comments",
-          "inboxes": "https://api2.frontapp.com/conversations/cnv_11sdgij/inboxes"
+          "inboxes": "https://api2.frontapp.com/conversations/cnv_11sdgij/inboxes",
+          "last_message": "https://api2.frontapp.com/messages/msg_1y9ecqj"
         }
       },
       "id": "cnv_11sdgij",
@@ -42,46 +43,6 @@
         "role": "from"
       },
       "tags": [],
-      "last_message": {
-        "_links": {
-          "self": "https://api2.frontapp.com/messages/msg_1y9ecqj",
-          "related": {
-            "conversation": "https://api2.frontapp.com/conversations/cnv_11sdgij"
-          }
-        },
-        "id": "msg_1y9ecqj",
-        "type": "email",
-        "is_inbound": true,
-        "created_at": 1539207321.998,
-        "blurb": " ",
-        "body": "<div><br /></div>\n",
-        "text": "\n",
-        "is_draft": false,
-        "error_type": null,
-        "metadata": {},
-        "author": null,
-        "recipients": [
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_5ef35"
-              }
-            },
-            "handle": "juan@resin.io",
-            "role": "from"
-          },
-          {
-            "_links": {
-              "related": {
-                "contact": null
-              }
-            },
-            "handle": "ei8z-resin_io@in.frontapp.com",
-            "role": "to"
-          }
-        ],
-        "attachments": []
-      },
       "created_at": 1539207322.171,
       "is_private": false
     },

--- a/test/integration/webhooks/inbound-snooze/stubs/1/messages-msg-1-y-9-ecqj.json
+++ b/test/integration/webhooks/inbound-snooze/stubs/1/messages-msg-1-y-9-ecqj.json
@@ -1,0 +1,40 @@
+{
+    "_links": {
+      "self": "https://api2.frontapp.com/messages/msg_1y9ecqj",
+      "related": {
+        "conversation": "https://api2.frontapp.com/conversations/cnv_11sdgij"
+      }
+    },
+    "id": "msg_1y9ecqj",
+    "type": "email",
+    "is_inbound": true,
+    "created_at": 1539207321.998,
+    "blurb": " ",
+    "body": "<div><br /></div>\n",
+    "text": "\n",
+    "is_draft": false,
+    "error_type": null,
+    "metadata": {},
+    "author": null,
+    "recipients": [
+      {
+        "_links": {
+          "related": {
+            "contact": "https://api2.frontapp.com/contacts/crd_5ef35"
+          }
+        },
+        "handle": "juan@resin.io",
+        "role": "from"
+      },
+      {
+        "_links": {
+          "related": {
+            "contact": null
+          }
+        },
+        "handle": "ei8z-resin_io@in.frontapp.com",
+        "role": "to"
+      }
+    ],
+    "attachments": []
+}

--- a/test/integration/webhooks/inbound-tag-comment/01.json
+++ b/test/integration/webhooks/inbound-tag-comment/01.json
@@ -25,7 +25,8 @@
           "followers": "https://api2.frontapp.com/conversations/cnv_183bv6i/followers",
           "messages": "https://api2.frontapp.com/conversations/cnv_183bv6i/messages",
           "comments": "https://api2.frontapp.com/conversations/cnv_183bv6i/comments",
-          "inboxes": "https://api2.frontapp.com/conversations/cnv_183bv6i/inboxes"
+          "inboxes": "https://api2.frontapp.com/conversations/cnv_183bv6i/inboxes",
+          "last_message": "https://api2.frontapp.com/messages/msg_28s4nei"
         }
       },
       "id": "cnv_183bv6i",
@@ -42,46 +43,6 @@
         "role": "from"
       },
       "tags": [],
-      "last_message": {
-        "_links": {
-          "self": "https://api2.frontapp.com/messages/msg_28s4nei",
-          "related": {
-            "conversation": "https://api2.frontapp.com/conversations/cnv_183bv6i"
-          }
-        },
-        "id": "msg_28s4nei",
-        "type": "email",
-        "is_inbound": true,
-        "created_at": 1547829291.902,
-        "blurb": " Foo ",
-        "body": "<div>Foo</div>\n",
-        "text": "Foo\n",
-        "is_draft": false,
-        "error_type": null,
-        "metadata": {},
-        "author": null,
-        "recipients": [
-          {
-            "_links": {
-              "related": {
-                "contact": null
-              }
-            },
-            "handle": "juan@balena.io",
-            "role": "from"
-          },
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_hgkpe"
-              }
-            },
-            "handle": "26ww-resin_io_dev@in.frontapp.com",
-            "role": "to"
-          }
-        ],
-        "attachments": []
-      },
       "created_at": 1547829293.073,
       "is_private": false
     },

--- a/test/integration/webhooks/inbound-tag-comment/02.json
+++ b/test/integration/webhooks/inbound-tag-comment/02.json
@@ -25,7 +25,8 @@
           "followers": "https://api2.frontapp.com/conversations/cnv_183bv6i/followers",
           "messages": "https://api2.frontapp.com/conversations/cnv_183bv6i/messages",
           "comments": "https://api2.frontapp.com/conversations/cnv_183bv6i/comments",
-          "inboxes": "https://api2.frontapp.com/conversations/cnv_183bv6i/inboxes"
+          "inboxes": "https://api2.frontapp.com/conversations/cnv_183bv6i/inboxes",
+          "last_message": "https://api2.frontapp.com/messages/msg_28s4nei"
         }
       },
       "id": "cnv_183bv6i",
@@ -55,46 +56,6 @@
           "is_private": false
         }
       ],
-      "last_message": {
-        "_links": {
-          "self": "https://api2.frontapp.com/messages/msg_28s4nei",
-          "related": {
-            "conversation": "https://api2.frontapp.com/conversations/cnv_183bv6i"
-          }
-        },
-        "id": "msg_28s4nei",
-        "type": "email",
-        "is_inbound": true,
-        "created_at": 1547829291.902,
-        "blurb": " Foo ",
-        "body": "<div>Foo</div>\n",
-        "text": "Foo\n",
-        "is_draft": false,
-        "error_type": null,
-        "metadata": {},
-        "author": null,
-        "recipients": [
-          {
-            "_links": {
-              "related": {
-                "contact": null
-              }
-            },
-            "handle": "juan@balena.io",
-            "role": "from"
-          },
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_hgkpe"
-              }
-            },
-            "handle": "26ww-resin_io_dev@in.frontapp.com",
-            "role": "to"
-          }
-        ],
-        "attachments": []
-      },
       "created_at": 1547829293.073,
       "is_private": false
     },

--- a/test/integration/webhooks/inbound-tag-comment/03.json
+++ b/test/integration/webhooks/inbound-tag-comment/03.json
@@ -25,7 +25,8 @@
           "followers": "https://api2.frontapp.com/conversations/cnv_183bv6i/followers",
           "messages": "https://api2.frontapp.com/conversations/cnv_183bv6i/messages",
           "comments": "https://api2.frontapp.com/conversations/cnv_183bv6i/comments",
-          "inboxes": "https://api2.frontapp.com/conversations/cnv_183bv6i/inboxes"
+          "inboxes": "https://api2.frontapp.com/conversations/cnv_183bv6i/inboxes",
+          "last_message": "https://api2.frontapp.com/messages/msg_28s4nei"
         }
       },
       "id": "cnv_183bv6i",
@@ -55,46 +56,6 @@
           "is_private": false
         }
       ],
-      "last_message": {
-        "_links": {
-          "self": "https://api2.frontapp.com/messages/msg_28s4nei",
-          "related": {
-            "conversation": "https://api2.frontapp.com/conversations/cnv_183bv6i"
-          }
-        },
-        "id": "msg_28s4nei",
-        "type": "email",
-        "is_inbound": true,
-        "created_at": 1547829291.902,
-        "blurb": " Foo ",
-        "body": "<div>Foo</div>\n",
-        "text": "Foo\n",
-        "is_draft": false,
-        "error_type": null,
-        "metadata": {},
-        "author": null,
-        "recipients": [
-          {
-            "_links": {
-              "related": {
-                "contact": null
-              }
-            },
-            "handle": "juan@balena.io",
-            "role": "from"
-          },
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_hgkpe"
-              }
-            },
-            "handle": "26ww-resin_io_dev@in.frontapp.com",
-            "role": "to"
-          }
-        ],
-        "attachments": []
-      },
       "created_at": 1547829293.073,
       "is_private": false
     },

--- a/test/integration/webhooks/inbound-tag-comment/stubs/1/messages-msg-28-s-4-nei.json
+++ b/test/integration/webhooks/inbound-tag-comment/stubs/1/messages-msg-28-s-4-nei.json
@@ -1,0 +1,40 @@
+{
+    "_links": {
+      "self": "https://api2.frontapp.com/messages/msg_28s4nei",
+      "related": {
+        "conversation": "https://api2.frontapp.com/conversations/cnv_183bv6i"
+      }
+    },
+    "id": "msg_28s4nei",
+    "type": "email",
+    "is_inbound": true,
+    "created_at": 1547829291.902,
+    "blurb": " Foo ",
+    "body": "<div>Foo</div>\n",
+    "text": "Foo\n",
+    "is_draft": false,
+    "error_type": null,
+    "metadata": {},
+    "author": null,
+    "recipients": [
+      {
+        "_links": {
+          "related": {
+            "contact": null
+          }
+        },
+        "handle": "juan@balena.io",
+        "role": "from"
+      },
+      {
+        "_links": {
+          "related": {
+            "contact": "https://api2.frontapp.com/contacts/crd_hgkpe"
+          }
+        },
+        "handle": "26ww-resin_io_dev@in.frontapp.com",
+        "role": "to"
+      }
+    ],
+    "attachments": []
+}

--- a/test/integration/webhooks/inbound-tag-tag/01.json
+++ b/test/integration/webhooks/inbound-tag-tag/01.json
@@ -25,7 +25,8 @@
           "followers": "https://api2.frontapp.com/conversations/cnv_11dvyca/followers",
           "messages": "https://api2.frontapp.com/conversations/cnv_11dvyca/messages",
           "comments": "https://api2.frontapp.com/conversations/cnv_11dvyca/comments",
-          "inboxes": "https://api2.frontapp.com/conversations/cnv_11dvyca/inboxes"
+          "inboxes": "https://api2.frontapp.com/conversations/cnv_11dvyca/inboxes",
+          "last_message": "https://api2.frontapp.com/messages/msg_1w1f12q"
         }
       },
       "id": "cnv_11dvyca",
@@ -42,46 +43,6 @@
         "role": "from"
       },
       "tags": [],
-      "last_message": {
-        "_links": {
-          "self": "https://api2.frontapp.com/messages/msg_1w1f12q",
-          "related": {
-            "conversation": "https://api2.frontapp.com/conversations/cnv_11dvyca"
-          }
-        },
-        "id": "msg_1w1f12q",
-        "type": "email",
-        "is_inbound": true,
-        "created_at": 1539023788.538,
-        "blurb": " Hello ",
-        "body": "<div>Hello</div>\n",
-        "text": "Hello\n",
-        "is_draft": false,
-        "error_type": null,
-        "metadata": {},
-        "author": null,
-        "recipients": [
-          {
-            "_links": {
-              "related": {
-                "contact": null
-              }
-            },
-            "handle": "juan@resin.io",
-            "role": "from"
-          },
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_hgkpe"
-              }
-            },
-            "handle": "26ww-resin_io_dev@in.frontapp.com",
-            "role": "to"
-          }
-        ],
-        "attachments": []
-      },
       "created_at": 1539023789.628,
       "is_private": false
     },

--- a/test/integration/webhooks/inbound-tag-tag/03.json
+++ b/test/integration/webhooks/inbound-tag-tag/03.json
@@ -25,7 +25,8 @@
           "followers": "https://api2.frontapp.com/conversations/cnv_11dvyca/followers",
           "messages": "https://api2.frontapp.com/conversations/cnv_11dvyca/messages",
           "comments": "https://api2.frontapp.com/conversations/cnv_11dvyca/comments",
-          "inboxes": "https://api2.frontapp.com/conversations/cnv_11dvyca/inboxes"
+          "inboxes": "https://api2.frontapp.com/conversations/cnv_11dvyca/inboxes",
+          "last_message": "https://api2.frontapp.com/messages/msg_1w1f12q"
         }
       },
       "id": "cnv_11dvyca",
@@ -67,46 +68,6 @@
           "is_private": false
         }
       ],
-      "last_message": {
-        "_links": {
-          "self": "https://api2.frontapp.com/messages/msg_1w1f12q",
-          "related": {
-            "conversation": "https://api2.frontapp.com/conversations/cnv_11dvyca"
-          }
-        },
-        "id": "msg_1w1f12q",
-        "type": "email",
-        "is_inbound": true,
-        "created_at": 1539023788.538,
-        "blurb": " Hello ",
-        "body": "<div>Hello</div>\n",
-        "text": "Hello\n",
-        "is_draft": false,
-        "error_type": null,
-        "metadata": {},
-        "author": null,
-        "recipients": [
-          {
-            "_links": {
-              "related": {
-                "contact": null
-              }
-            },
-            "handle": "juan@resin.io",
-            "role": "from"
-          },
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_hgkpe"
-              }
-            },
-            "handle": "26ww-resin_io_dev@in.frontapp.com",
-            "role": "to"
-          }
-        ],
-        "attachments": []
-      },
       "created_at": 1539023789.628,
       "is_private": false
     },

--- a/test/integration/webhooks/inbound-tag-tag/stubs/1/messages-msg-1-w-1-f-12-q.json
+++ b/test/integration/webhooks/inbound-tag-tag/stubs/1/messages-msg-1-w-1-f-12-q.json
@@ -1,0 +1,40 @@
+{
+    "_links": {
+      "self": "https://api2.frontapp.com/messages/msg_1w1f12q",
+      "related": {
+        "conversation": "https://api2.frontapp.com/conversations/cnv_11dvyca"
+      }
+    },
+    "id": "msg_1w1f12q",
+    "type": "email",
+    "is_inbound": true,
+    "created_at": 1539023788.538,
+    "blurb": " Hello ",
+    "body": "<div>Hello</div>\n",
+    "text": "Hello\n",
+    "is_draft": false,
+    "error_type": null,
+    "metadata": {},
+    "author": null,
+    "recipients": [
+      {
+        "_links": {
+          "related": {
+            "contact": null
+          }
+        },
+        "handle": "juan@resin.io",
+        "role": "from"
+      },
+      {
+        "_links": {
+          "related": {
+            "contact": "https://api2.frontapp.com/contacts/crd_hgkpe"
+          }
+        },
+        "handle": "26ww-resin_io_dev@in.frontapp.com",
+        "role": "to"
+      }
+    ],
+    "attachments": []
+}

--- a/test/integration/webhooks/inbound-tag-untag/01.json
+++ b/test/integration/webhooks/inbound-tag-untag/01.json
@@ -25,7 +25,8 @@
           "followers": "https://api2.frontapp.com/conversations/cnv_11dw1xu/followers",
           "messages": "https://api2.frontapp.com/conversations/cnv_11dw1xu/messages",
           "comments": "https://api2.frontapp.com/conversations/cnv_11dw1xu/comments",
-          "inboxes": "https://api2.frontapp.com/conversations/cnv_11dw1xu/inboxes"
+          "inboxes": "https://api2.frontapp.com/conversations/cnv_11dw1xu/inboxes",
+          "last_message": "https://api2.frontapp.com/messages/msg_1w1f6h6"
         }
       },
       "id": "cnv_11dw1xu",
@@ -42,46 +43,6 @@
         "role": "from"
       },
       "tags": [],
-      "last_message": {
-        "_links": {
-          "self": "https://api2.frontapp.com/messages/msg_1w1f6h6",
-          "related": {
-            "conversation": "https://api2.frontapp.com/conversations/cnv_11dw1xu"
-          }
-        },
-        "id": "msg_1w1f6h6",
-        "type": "email",
-        "is_inbound": true,
-        "created_at": 1539023870.787,
-        "blurb": " foo ",
-        "body": "<div>foo</div>\n",
-        "text": "foo\n",
-        "is_draft": false,
-        "error_type": null,
-        "metadata": {},
-        "author": null,
-        "recipients": [
-          {
-            "_links": {
-              "related": {
-                "contact": null
-              }
-            },
-            "handle": "juan@resin.io",
-            "role": "from"
-          },
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_hgkpe"
-              }
-            },
-            "handle": "26ww-resin_io_dev@in.frontapp.com",
-            "role": "to"
-          }
-        ],
-        "attachments": []
-      },
       "created_at": 1539023871.995,
       "is_private": false
     },

--- a/test/integration/webhooks/inbound-tag-untag/02.json
+++ b/test/integration/webhooks/inbound-tag-untag/02.json
@@ -25,7 +25,8 @@
           "followers": "https://api2.frontapp.com/conversations/cnv_11dw1xu/followers",
           "messages": "https://api2.frontapp.com/conversations/cnv_11dw1xu/messages",
           "comments": "https://api2.frontapp.com/conversations/cnv_11dw1xu/comments",
-          "inboxes": "https://api2.frontapp.com/conversations/cnv_11dw1xu/inboxes"
+          "inboxes": "https://api2.frontapp.com/conversations/cnv_11dw1xu/inboxes",
+          "last_message": "https://api2.frontapp.com/messages/msg_1w1f6h6"
         }
       },
       "id": "cnv_11dw1xu",
@@ -55,46 +56,6 @@
           "is_private": false
         }
       ],
-      "last_message": {
-        "_links": {
-          "self": "https://api2.frontapp.com/messages/msg_1w1f6h6",
-          "related": {
-            "conversation": "https://api2.frontapp.com/conversations/cnv_11dw1xu"
-          }
-        },
-        "id": "msg_1w1f6h6",
-        "type": "email",
-        "is_inbound": true,
-        "created_at": 1539023870.787,
-        "blurb": " foo ",
-        "body": "<div>foo</div>\n",
-        "text": "foo\n",
-        "is_draft": false,
-        "error_type": null,
-        "metadata": {},
-        "author": null,
-        "recipients": [
-          {
-            "_links": {
-              "related": {
-                "contact": null
-              }
-            },
-            "handle": "juan@resin.io",
-            "role": "from"
-          },
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_hgkpe"
-              }
-            },
-            "handle": "26ww-resin_io_dev@in.frontapp.com",
-            "role": "to"
-          }
-        ],
-        "attachments": []
-      },
       "created_at": 1539023871.995,
       "is_private": false
     },

--- a/test/integration/webhooks/inbound-tag-untag/03.json
+++ b/test/integration/webhooks/inbound-tag-untag/03.json
@@ -25,7 +25,8 @@
           "followers": "https://api2.frontapp.com/conversations/cnv_11dw1xu/followers",
           "messages": "https://api2.frontapp.com/conversations/cnv_11dw1xu/messages",
           "comments": "https://api2.frontapp.com/conversations/cnv_11dw1xu/comments",
-          "inboxes": "https://api2.frontapp.com/conversations/cnv_11dw1xu/inboxes"
+          "inboxes": "https://api2.frontapp.com/conversations/cnv_11dw1xu/inboxes",
+          "last_message": "https://api2.frontapp.com/messages/msg_1w1f6h6"
         }
       },
       "id": "cnv_11dw1xu",
@@ -42,46 +43,6 @@
         "role": "from"
       },
       "tags": [],
-      "last_message": {
-        "_links": {
-          "self": "https://api2.frontapp.com/messages/msg_1w1f6h6",
-          "related": {
-            "conversation": "https://api2.frontapp.com/conversations/cnv_11dw1xu"
-          }
-        },
-        "id": "msg_1w1f6h6",
-        "type": "email",
-        "is_inbound": true,
-        "created_at": 1539023870.787,
-        "blurb": " foo ",
-        "body": "<div>foo</div>\n",
-        "text": "foo\n",
-        "is_draft": false,
-        "error_type": null,
-        "metadata": {},
-        "author": null,
-        "recipients": [
-          {
-            "_links": {
-              "related": {
-                "contact": null
-              }
-            },
-            "handle": "juan@resin.io",
-            "role": "from"
-          },
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_hgkpe"
-              }
-            },
-            "handle": "26ww-resin_io_dev@in.frontapp.com",
-            "role": "to"
-          }
-        ],
-        "attachments": []
-      },
       "created_at": 1539023871.995,
       "is_private": false
     },

--- a/test/integration/webhooks/inbound-tag-untag/stubs/1/messages-msg-1-w-1-f-6-h-6.json
+++ b/test/integration/webhooks/inbound-tag-untag/stubs/1/messages-msg-1-w-1-f-6-h-6.json
@@ -1,0 +1,40 @@
+{
+    "_links": {
+      "self": "https://api2.frontapp.com/messages/msg_1w1f6h6",
+      "related": {
+        "conversation": "https://api2.frontapp.com/conversations/cnv_11dw1xu"
+      }
+    },
+    "id": "msg_1w1f6h6",
+    "type": "email",
+    "is_inbound": true,
+    "created_at": 1539023870.787,
+    "blurb": " foo ",
+    "body": "<div>foo</div>\n",
+    "text": "foo\n",
+    "is_draft": false,
+    "error_type": null,
+    "metadata": {},
+    "author": null,
+    "recipients": [
+      {
+        "_links": {
+          "related": {
+            "contact": null
+          }
+        },
+        "handle": "juan@resin.io",
+        "role": "from"
+      },
+      {
+        "_links": {
+          "related": {
+            "contact": "https://api2.frontapp.com/contacts/crd_hgkpe"
+          }
+        },
+        "handle": "26ww-resin_io_dev@in.frontapp.com",
+        "role": "to"
+      }
+    ],
+    "attachments": []
+}

--- a/test/integration/webhooks/index.ts
+++ b/test/integration/webhooks/index.ts
@@ -1,5 +1,4 @@
 export default {
-	/*
 	'inbound-message-multiple-inboxes': {
 		expected: require('./inbound-message-multiple-inboxes/expected.json'),
 		steps: [
@@ -240,7 +239,6 @@ export default {
 			require('./inbound-comment-comment/03.json'),
 		],
 	},
-	*/
 	'inbound-archive-message': {
 		expected: require('./inbound-archive-message/expected.json'),
 		steps: [
@@ -251,7 +249,6 @@ export default {
 			require('./inbound-archive-message/05.json'),
 		],
 	},
-	/*
 	'inbound-delete-message': {
 		expected: require('./inbound-delete-message/expected.json'),
 		steps: [
@@ -274,5 +271,4 @@ export default {
 		expected: require('./intercom-no-author/expected.json'),
 		steps: [require('./intercom-no-author/01.json')],
 	},
-	*/
 };

--- a/test/integration/webhooks/intercom-draft-comment/01.json
+++ b/test/integration/webhooks/intercom-draft-comment/01.json
@@ -25,7 +25,8 @@
           "followers": "https://api2.frontapp.com/conversations/cnv_173u3mz/followers",
           "messages": "https://api2.frontapp.com/conversations/cnv_173u3mz/messages",
           "comments": "https://api2.frontapp.com/conversations/cnv_173u3mz/comments",
-          "inboxes": "https://api2.frontapp.com/conversations/cnv_173u3mz/inboxes"
+          "inboxes": "https://api2.frontapp.com/conversations/cnv_173u3mz/inboxes",
+          "last_message": "https://api2.frontapp.com/messages/msg_29osuib"
         }
       },
       "id": "cnv_173u3mz",
@@ -42,48 +43,6 @@
         "role": "from"
       },
       "tags": [],
-      "last_message": {
-        "_links": {
-          "self": "https://api2.frontapp.com/messages/msg_29osuib",
-          "related": {
-            "conversation": "https://api2.frontapp.com/conversations/cnv_173u3mz"
-          }
-        },
-        "id": "msg_29osuib",
-        "type": "intercom",
-        "is_inbound": true,
-        "created_at": 1547720312,
-        "blurb": " JF test, please ignore ",
-        "body": "<div><p>JF test, please ignore</p>\n</div>",
-        "text": "JF test, please ignore",
-        "is_draft": false,
-        "error_type": null,
-        "metadata": {
-          "intercom_url": "https://app.intercom.io/a/apps/yg02r5dz/inbox/conversation/20454340990"
-        },
-        "author": null,
-        "recipients": [
-          {
-            "_links": {
-              "related": {
-                "contact": null
-              }
-            },
-            "handle": "5457936368f6f465d7002858",
-            "role": "from"
-          },
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_5gqtnd"
-              }
-            },
-            "handle": "yg02r5dz",
-            "role": "to"
-          }
-        ],
-        "attachments": []
-      },
       "created_at": 1547720314.252,
       "is_private": false
     },

--- a/test/integration/webhooks/intercom-draft-comment/02.json
+++ b/test/integration/webhooks/intercom-draft-comment/02.json
@@ -25,7 +25,8 @@
           "followers": "https://api2.frontapp.com/conversations/cnv_173u3mz/followers",
           "messages": "https://api2.frontapp.com/conversations/cnv_173u3mz/messages",
           "comments": "https://api2.frontapp.com/conversations/cnv_173u3mz/comments",
-          "inboxes": "https://api2.frontapp.com/conversations/cnv_173u3mz/inboxes"
+          "inboxes": "https://api2.frontapp.com/conversations/cnv_173u3mz/inboxes",
+          "last_message": "https://api2.frontapp.com/messages/msg_29osuib"
         }
       },
       "id": "cnv_173u3mz",
@@ -42,48 +43,6 @@
         "role": "from"
       },
       "tags": [],
-      "last_message": {
-        "_links": {
-          "self": "https://api2.frontapp.com/messages/msg_29osuib",
-          "related": {
-            "conversation": "https://api2.frontapp.com/conversations/cnv_173u3mz"
-          }
-        },
-        "id": "msg_29osuib",
-        "type": "intercom",
-        "is_inbound": true,
-        "created_at": 1547720312,
-        "blurb": " JF test, please ignore ",
-        "body": "<div><p>JF test, please ignore</p>\n</div>",
-        "text": "JF test, please ignore",
-        "is_draft": false,
-        "error_type": null,
-        "metadata": {
-          "intercom_url": "https://app.intercom.io/a/apps/yg02r5dz/inbox/conversation/20454340990"
-        },
-        "author": null,
-        "recipients": [
-          {
-            "_links": {
-              "related": {
-                "contact": null
-              }
-            },
-            "handle": "5457936368f6f465d7002858",
-            "role": "from"
-          },
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_5gqtnd"
-              }
-            },
-            "handle": "yg02r5dz",
-            "role": "to"
-          }
-        ],
-        "attachments": []
-      },
       "created_at": 1547720314.252,
       "is_private": false
     },

--- a/test/integration/webhooks/intercom-draft-comment/stubs/1/messages-msg-29-osuib.json
+++ b/test/integration/webhooks/intercom-draft-comment/stubs/1/messages-msg-29-osuib.json
@@ -1,0 +1,42 @@
+{
+    "_links": {
+      "self": "https://api2.frontapp.com/messages/msg_29osuib",
+      "related": {
+        "conversation": "https://api2.frontapp.com/conversations/cnv_173u3mz"
+      }
+    },
+    "id": "msg_29osuib",
+    "type": "intercom",
+    "is_inbound": true,
+    "created_at": 1547720312,
+    "blurb": " JF test, please ignore ",
+    "body": "<div><p>JF test, please ignore</p>\n</div>",
+    "text": "JF test, please ignore",
+    "is_draft": false,
+    "error_type": null,
+    "metadata": {
+      "intercom_url": "https://app.intercom.io/a/apps/yg02r5dz/inbox/conversation/20454340990"
+    },
+    "author": null,
+    "recipients": [
+      {
+        "_links": {
+          "related": {
+            "contact": null
+          }
+        },
+        "handle": "5457936368f6f465d7002858",
+        "role": "from"
+      },
+      {
+        "_links": {
+          "related": {
+            "contact": "https://api2.frontapp.com/contacts/crd_5gqtnd"
+          }
+        },
+        "handle": "yg02r5dz",
+        "role": "to"
+      }
+    ],
+    "attachments": []
+}

--- a/test/integration/webhooks/intercom-draft-message/01.json
+++ b/test/integration/webhooks/intercom-draft-message/01.json
@@ -25,7 +25,8 @@
           "followers": "https://api2.frontapp.com/conversations/cnv_173uno3/followers",
           "messages": "https://api2.frontapp.com/conversations/cnv_173uno3/messages",
           "comments": "https://api2.frontapp.com/conversations/cnv_173uno3/comments",
-          "inboxes": "https://api2.frontapp.com/conversations/cnv_173uno3/inboxes"
+          "inboxes": "https://api2.frontapp.com/conversations/cnv_173uno3/inboxes",
+          "last_message": "https://api2.frontapp.com/messages/msg_29otzx7"
         }
       },
       "id": "cnv_173uno3",
@@ -42,48 +43,6 @@
         "role": "from"
       },
       "tags": [],
-      "last_message": {
-        "_links": {
-          "self": "https://api2.frontapp.com/messages/msg_29otzx7",
-          "related": {
-            "conversation": "https://api2.frontapp.com/conversations/cnv_173uno3"
-          }
-        },
-        "id": "msg_29otzx7",
-        "type": "intercom",
-        "is_inbound": true,
-        "created_at": 1547721760,
-        "blurb": " JF test (ignore) ",
-        "body": "<div><p>JF test (ignore)</p>\n</div>",
-        "text": "JF test (ignore)",
-        "is_draft": false,
-        "error_type": null,
-        "metadata": {
-          "intercom_url": "https://app.intercom.io/a/apps/yg02r5dz/inbox/conversation/20454527100"
-        },
-        "author": null,
-        "recipients": [
-          {
-            "_links": {
-              "related": {
-                "contact": null
-              }
-            },
-            "handle": "5457936368f6f465d7002858",
-            "role": "from"
-          },
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_5gqtnd"
-              }
-            },
-            "handle": "yg02r5dz",
-            "role": "to"
-          }
-        ],
-        "attachments": []
-      },
       "created_at": 1547721763.662,
       "is_private": false
     },

--- a/test/integration/webhooks/intercom-draft-message/02.json
+++ b/test/integration/webhooks/intercom-draft-message/02.json
@@ -25,7 +25,8 @@
           "followers": "https://api2.frontapp.com/conversations/cnv_173uno3/followers",
           "messages": "https://api2.frontapp.com/conversations/cnv_173uno3/messages",
           "comments": "https://api2.frontapp.com/conversations/cnv_173uno3/comments",
-          "inboxes": "https://api2.frontapp.com/conversations/cnv_173uno3/inboxes"
+          "inboxes": "https://api2.frontapp.com/conversations/cnv_173uno3/inboxes",
+          "last_message": "https://api2.frontapp.com/messages/msg_29otzx7"
         }
       },
       "id": "cnv_173uno3",
@@ -42,48 +43,6 @@
         "role": "from"
       },
       "tags": [],
-      "last_message": {
-        "_links": {
-          "self": "https://api2.frontapp.com/messages/msg_29otzx7",
-          "related": {
-            "conversation": "https://api2.frontapp.com/conversations/cnv_173uno3"
-          }
-        },
-        "id": "msg_29otzx7",
-        "type": "intercom",
-        "is_inbound": true,
-        "created_at": 1547721760,
-        "blurb": " JF test (ignore) ",
-        "body": "<div><p>JF test (ignore)</p>\n</div>",
-        "text": "JF test (ignore)",
-        "is_draft": false,
-        "error_type": null,
-        "metadata": {
-          "intercom_url": "https://app.intercom.io/a/apps/yg02r5dz/inbox/conversation/20454527100"
-        },
-        "author": null,
-        "recipients": [
-          {
-            "_links": {
-              "related": {
-                "contact": null
-              }
-            },
-            "handle": "5457936368f6f465d7002858",
-            "role": "from"
-          },
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_5gqtnd"
-              }
-            },
-            "handle": "yg02r5dz",
-            "role": "to"
-          }
-        ],
-        "attachments": []
-      },
       "created_at": 1547721763.662,
       "is_private": false
     },

--- a/test/integration/webhooks/intercom-draft-message/stubs/1/messages-msg-29-otzx-7.json
+++ b/test/integration/webhooks/intercom-draft-message/stubs/1/messages-msg-29-otzx-7.json
@@ -1,0 +1,42 @@
+{
+    "_links": {
+      "self": "https://api2.frontapp.com/messages/msg_29otzx7",
+      "related": {
+        "conversation": "https://api2.frontapp.com/conversations/cnv_173uno3"
+      }
+    },
+    "id": "msg_29otzx7",
+    "type": "intercom",
+    "is_inbound": true,
+    "created_at": 1547721760,
+    "blurb": " JF test (ignore) ",
+    "body": "<div><p>JF test (ignore)</p>\n</div>",
+    "text": "JF test (ignore)",
+    "is_draft": false,
+    "error_type": null,
+    "metadata": {
+      "intercom_url": "https://app.intercom.io/a/apps/yg02r5dz/inbox/conversation/20454527100"
+    },
+    "author": null,
+    "recipients": [
+      {
+        "_links": {
+          "related": {
+            "contact": null
+          }
+        },
+        "handle": "5457936368f6f465d7002858",
+        "role": "from"
+      },
+      {
+        "_links": {
+          "related": {
+            "contact": "https://api2.frontapp.com/contacts/crd_5gqtnd"
+          }
+        },
+        "handle": "yg02r5dz",
+        "role": "to"
+      }
+    ],
+    "attachments": []
+}

--- a/test/integration/webhooks/intercom-inbound-archive-email-prefix/stubs/1/messages-msg-27-e-04-ar.json
+++ b/test/integration/webhooks/intercom-inbound-archive-email-prefix/stubs/1/messages-msg-27-e-04-ar.json
@@ -1,0 +1,42 @@
+{
+    "_links": {
+      "self": "https://api2.frontapp.com/messages/msg_27e04ar",
+      "related": {
+        "conversation": "https://api2.frontapp.com/conversations/cnv_162d17f"
+      }
+    },
+    "id": "msg_27e04ar",
+    "type": "intercom",
+    "is_inbound": true,
+    "created_at": 1545923308,
+    "blurb": " Test test 2 ",
+    "body": "<div><p>Test test 2</p>\n</div>",
+    "text": "Test test 2",
+    "is_draft": false,
+    "error_type": null,
+    "metadata": {
+      "intercom_url": "https://app.intercom.io/a/apps/yg02r5dz/inbox/conversation/20199552045"
+    },
+    "author": null,
+    "recipients": [
+      {
+        "_links": {
+          "related": {
+            "contact": null
+          }
+        },
+        "handle": "5457936368f6f465d7002858",
+        "role": "from"
+      },
+      {
+        "_links": {
+          "related": {
+            "contact": "https://api2.frontapp.com/contacts/crd_5gqtnd"
+          }
+        },
+        "handle": "yg02r5dz",
+        "role": "to"
+      }
+    ],
+    "attachments": []
+}

--- a/test/integration/webhooks/intercom-inbound-archive/stubs/1/messages-msg-27-e-04-ar.json
+++ b/test/integration/webhooks/intercom-inbound-archive/stubs/1/messages-msg-27-e-04-ar.json
@@ -1,0 +1,42 @@
+{
+    "_links": {
+      "self": "https://api2.frontapp.com/messages/msg_27e04ar",
+      "related": {
+        "conversation": "https://api2.frontapp.com/conversations/cnv_162d17f"
+      }
+    },
+    "id": "msg_27e04ar",
+    "type": "intercom",
+    "is_inbound": true,
+    "created_at": 1545923308,
+    "blurb": " Test test 2 ",
+    "body": "<div><p>Test test 2</p>\n</div>",
+    "text": "Test test 2",
+    "is_draft": false,
+    "error_type": null,
+    "metadata": {
+      "intercom_url": "https://app.intercom.io/a/apps/yg02r5dz/inbox/conversation/20199552045"
+    },
+    "author": null,
+    "recipients": [
+      {
+        "_links": {
+          "related": {
+            "contact": null
+          }
+        },
+        "handle": "5457936368f6f465d7002858",
+        "role": "from"
+      },
+      {
+        "_links": {
+          "related": {
+            "contact": "https://api2.frontapp.com/contacts/crd_5gqtnd"
+          }
+        },
+        "handle": "yg02r5dz",
+        "role": "to"
+      }
+    ],
+    "attachments": []
+}

--- a/test/integration/webhooks/intercom-no-author/stubs/1/messages-msg-284-xm-4-z.json
+++ b/test/integration/webhooks/intercom-no-author/stubs/1/messages-msg-284-xm-4-z.json
@@ -1,0 +1,44 @@
+{
+    "_links": {
+      "related": {
+        "conversation": "https://api2.frontapp.com/conversations/cnv_16ax9l7"
+      },
+      "self": "https://api2.frontapp.com/messages/msg_284xm4z"
+    },
+    "attachments": [],
+    "author": null,
+    "blurb": "",
+    "body": "<p>Hi dt-rush,<br />To run the commands on the host OS what we do is generate bash scripts at runtime using the users parameters (stored in /data) and before we reboot the device we run the script.  So they are running from the shell using the Command::new() portion of std::process::Command from Rust.  </p>\n<p>For some additional information about how the dockerfile looks here are the packages we are pulling in as well as the NetworkManager.service mask:</p>\n<p>---Snip---<br />FROM balenalib/amd64-ubuntu</p>\n<p>ENV INITSYSTEM on</p>\n<p>RUN apt-get update</p>\n<p>RUN apt-get install -y dnsmasq wireless-tools vim file udhcpd network-manager \\<br />    &amp;&amp; systemctl mask NetworkManager.service \\<br />    &amp;&amp; apt-get clean \\<br />    &amp;&amp; rm -rf /var/lib/apt/lists/*<br />---Snip---</p>\n<p>The rest is just some application specific stuff to put files in the container and run it.</p>\n<p>Ill look into the systemd service idea today.  One issue I am assuming I&#39;d need to solve is bringing up the new wifi interface before I reboot, I&#39;m not sure if NM will allow me to do that if the balena tunnel is running on another device however.  If you have any other suggestions or details around that approach I&#39;m listening.</p>\n<p>Thanks,<br />Brant</p>\n<a href=\"https://www.balena-cloud.com?hidden=reply&source=flowdock&flow=rulemotion/public-s-community&thread=TAz9aNXmYye6c4FeZGg-7MmHznc&hmac=d430d2534f80fa099bd2556deb1facc82d5dff927a1d6bec08e33a33e81466fc\" target=\"_blank\" rel=\"noopener noreferrer\"></a>",
+    "created_at": 1546612197.276,
+    "error_type": null,
+    "id": "msg_284xm4z",
+    "is_draft": false,
+    "is_inbound": false,
+    "metadata": {
+      "headers": {
+        "in_reply_to": "287f6fb565446cd6c9255a5bb1c6e3c9@frontapp.com"
+      }
+    },
+    "recipients": [
+      {
+        "_links": {
+          "related": {
+            "contact": "https://api2.frontapp.com/contacts/crd_2yqwmh"
+          }
+        },
+        "handle": "423a0f350b6f1102",
+        "role": "from"
+      },
+      {
+        "_links": {
+          "related": {
+            "contact": "https://api2.frontapp.com/contacts/crd_8rhkb7"
+          }
+        },
+        "handle": "BrantR",
+        "role": "to"
+      }
+    ],
+    "text": "Hi dt-rush,\nTo run the commands on the host OS what we do is generate bash scripts at runtime using the users parameters (stored in /data) and before we reboot the device we run the script. So they are running from the shell using the Command::new() portion of std::process::Command from Rust. \nFor some additional information about how the dockerfile looks here are the packages we are pulling in as well as the NetworkManager.service mask:\n---Snip---\nFROM balenalib/amd64-ubuntu\nENV INITSYSTEM on\nRUN apt-get update\nRUN apt-get install -y dnsmasq wireless-tools vim file udhcpd network-manager \\\n&& systemctl mask NetworkManager.service \\\n&& apt-get clean \\\n&& rm -rf /var/lib/apt/lists/*\n---Snip---\nThe rest is just some application specific stuff to put files in the container and run it.\nIll look into the systemd service idea today. One issue I am assuming I'd need to solve is bringing up the new wifi interface before I reboot, I'm not sure if NM will allow me to do that if the balena tunnel is running on another device however. If you have any other suggestions or details around that approach I'm listening.\nThanks,\nBrant",
+    "type": "custom"
+}

--- a/test/integration/webhooks/intercom-no-custom-attributes/stubs/1/messages-msg-29-osuib.json
+++ b/test/integration/webhooks/intercom-no-custom-attributes/stubs/1/messages-msg-29-osuib.json
@@ -1,0 +1,42 @@
+{
+    "_links": {
+      "self": "https://api2.frontapp.com/messages/msg_29osuib",
+      "related": {
+        "conversation": "https://api2.frontapp.com/conversations/cnv_173u3mz"
+      }
+    },
+    "id": "msg_29osuib",
+    "type": "intercom",
+    "is_inbound": true,
+    "created_at": 1547720312,
+    "blurb": " JF test, please ignore ",
+    "body": "<div><p>JF test, please ignore</p>\n</div>",
+    "text": "JF test, please ignore",
+    "is_draft": false,
+    "error_type": null,
+    "metadata": {
+      "intercom_url": "https://app.intercom.io/a/apps/yg02r5dz/inbox/conversation/20454340990"
+    },
+    "author": null,
+    "recipients": [
+      {
+        "_links": {
+          "related": {
+            "contact": null
+          }
+        },
+        "handle": "5457936368f6f465d7002858",
+        "role": "from"
+      },
+      {
+        "_links": {
+          "related": {
+            "contact": "https://api2.frontapp.com/contacts/crd_5gqtnd"
+          }
+        },
+        "handle": "yg02r5dz",
+        "role": "to"
+      }
+    ],
+    "attachments": []
+}

--- a/test/integration/webhooks/intercom-recap/02.json
+++ b/test/integration/webhooks/intercom-recap/02.json
@@ -26,7 +26,8 @@
           "events": "https://api2.frontapp.com/conversations/cnv_16a10wz/events",
           "followers": "https://api2.frontapp.com/conversations/cnv_16a10wz/followers",
           "inboxes": "https://api2.frontapp.com/conversations/cnv_16a10wz/inboxes",
-          "messages": "https://api2.frontapp.com/conversations/cnv_16a10wz/messages"
+          "messages": "https://api2.frontapp.com/conversations/cnv_16a10wz/messages",
+          "last_message": "https://api2.frontapp.com/messages/msg_280hbvv"
         },
         "self": "https://api2.frontapp.com/conversations/cnv_16a10wz"
       },
@@ -34,48 +35,6 @@
       "created_at": 1546448701.029,
       "id": "cnv_16a10wz",
       "is_private": false,
-      "last_message": {
-        "_links": {
-          "related": {
-            "conversation": "https://api2.frontapp.com/conversations/cnv_16a10wz"
-          },
-          "self": "https://api2.frontapp.com/messages/msg_280hbvv"
-        },
-        "attachments": [],
-        "author": null,
-        "blurb": " Sounds good, thanks! ",
-        "body": "<div><p>Sounds good, thanks!</p>\n</div>",
-        "created_at": 1546532088,
-        "error_type": null,
-        "id": "msg_280hbvv",
-        "is_draft": false,
-        "is_inbound": true,
-        "metadata": {
-          "intercom_url": "https://app.intercom.io/a/apps/yg02r5dz/inbox/conversation/20265921558"
-        },
-        "recipients": [
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_23f9g9"
-              }
-            },
-            "handle": "589b6c94e1832926cacecb02",
-            "role": "from"
-          },
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_5gqtnd"
-              }
-            },
-            "handle": "yg02r5dz",
-            "role": "to"
-          }
-        ],
-        "text": "Sounds good, thanks!",
-        "type": "intercom"
-      },
       "recipient": {
         "_links": {
           "related": {

--- a/test/integration/webhooks/intercom-recap/03.json
+++ b/test/integration/webhooks/intercom-recap/03.json
@@ -26,7 +26,8 @@
           "events": "https://api2.frontapp.com/conversations/cnv_16a10wz/events",
           "followers": "https://api2.frontapp.com/conversations/cnv_16a10wz/followers",
           "inboxes": "https://api2.frontapp.com/conversations/cnv_16a10wz/inboxes",
-          "messages": "https://api2.frontapp.com/conversations/cnv_16a10wz/messages"
+          "messages": "https://api2.frontapp.com/conversations/cnv_16a10wz/messages",
+          "last_message": "https://api2.frontapp.com/messages/msg_280hbvv"
         },
         "self": "https://api2.frontapp.com/conversations/cnv_16a10wz"
       },
@@ -34,48 +35,6 @@
       "created_at": 1546448701.029,
       "id": "cnv_16a10wz",
       "is_private": false,
-      "last_message": {
-        "_links": {
-          "related": {
-            "conversation": "https://api2.frontapp.com/conversations/cnv_16a10wz"
-          },
-          "self": "https://api2.frontapp.com/messages/msg_280hbvv"
-        },
-        "attachments": [],
-        "author": null,
-        "blurb": " Sounds good, thanks! ",
-        "body": "<div><p>Sounds good, thanks!</p>\n</div>",
-        "created_at": 1546532088,
-        "error_type": null,
-        "id": "msg_280hbvv",
-        "is_draft": false,
-        "is_inbound": true,
-        "metadata": {
-          "intercom_url": "https://app.intercom.io/a/apps/yg02r5dz/inbox/conversation/20265921558"
-        },
-        "recipients": [
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_23f9g9"
-              }
-            },
-            "handle": "589b6c94e1832926cacecb02",
-            "role": "from"
-          },
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_5gqtnd"
-              }
-            },
-            "handle": "yg02r5dz",
-            "role": "to"
-          }
-        ],
-        "text": "Sounds good, thanks!",
-        "type": "intercom"
-      },
       "recipient": {
         "_links": {
           "related": {

--- a/test/integration/webhooks/intercom-recap/stubs/1/messages-msg-280-hbvv.json
+++ b/test/integration/webhooks/intercom-recap/stubs/1/messages-msg-280-hbvv.json
@@ -1,0 +1,42 @@
+{
+    "_links": {
+      "related": {
+        "conversation": "https://api2.frontapp.com/conversations/cnv_16a10wz"
+      },
+      "self": "https://api2.frontapp.com/messages/msg_280hbvv"
+    },
+    "attachments": [],
+    "author": null,
+    "blurb": " Sounds good, thanks! ",
+    "body": "<div><p>Sounds good, thanks!</p>\n</div>",
+    "created_at": 1546532088,
+    "error_type": null,
+    "id": "msg_280hbvv",
+    "is_draft": false,
+    "is_inbound": true,
+    "metadata": {
+      "intercom_url": "https://app.intercom.io/a/apps/yg02r5dz/inbox/conversation/20265921558"
+    },
+    "recipients": [
+      {
+        "_links": {
+          "related": {
+            "contact": "https://api2.frontapp.com/contacts/crd_23f9g9"
+          }
+        },
+        "handle": "589b6c94e1832926cacecb02",
+        "role": "from"
+      },
+      {
+        "_links": {
+          "related": {
+            "contact": "https://api2.frontapp.com/contacts/crd_5gqtnd"
+          }
+        },
+        "handle": "yg02r5dz",
+        "role": "to"
+      }
+    ],
+    "text": "Sounds good, thanks!",
+    "type": "intercom"
+}

--- a/test/integration/webhooks/intercom-rule-reopen/01.json
+++ b/test/integration/webhooks/intercom-rule-reopen/01.json
@@ -26,7 +26,8 @@
           "events": "https://api2.frontapp.com/conversations/cnv_16ax9l7/events",
           "followers": "https://api2.frontapp.com/conversations/cnv_16ax9l7/followers",
           "inboxes": "https://api2.frontapp.com/conversations/cnv_16ax9l7/inboxes",
-          "messages": "https://api2.frontapp.com/conversations/cnv_16ax9l7/messages"
+          "messages": "https://api2.frontapp.com/conversations/cnv_16ax9l7/messages",
+          "last_message": "https://api2.frontapp.com/messages/msg_284xm4z"
         },
         "self": "https://api2.frontapp.com/conversations/cnv_16ax9l7"
       },
@@ -34,50 +35,6 @@
       "created_at": 1546464991.639,
       "id": "cnv_16ax9l7",
       "is_private": false,
-      "last_message": {
-        "_links": {
-          "related": {
-            "conversation": "https://api2.frontapp.com/conversations/cnv_16ax9l7"
-          },
-          "self": "https://api2.frontapp.com/messages/msg_284xm4z"
-        },
-        "attachments": [],
-        "author": null,
-        "blurb": "",
-        "body": "<p>Hi dt-rush,<br />To run the commands on the host OS what we do is generate bash scripts at runtime using the users parameters (stored in /data) and before we reboot the device we run the script.  So they are running from the shell using the Command::new() portion of std::process::Command from Rust.  </p>\n<p>For some additional information about how the dockerfile looks here are the packages we are pulling in as well as the NetworkManager.service mask:</p>\n<p>---Snip---<br />FROM balenalib/amd64-ubuntu</p>\n<p>ENV INITSYSTEM on</p>\n<p>RUN apt-get update</p>\n<p>RUN apt-get install -y dnsmasq wireless-tools vim file udhcpd network-manager \\<br />    &amp;&amp; systemctl mask NetworkManager.service \\<br />    &amp;&amp; apt-get clean \\<br />    &amp;&amp; rm -rf /var/lib/apt/lists/*<br />---Snip---</p>\n<p>The rest is just some application specific stuff to put files in the container and run it.</p>\n<p>Ill look into the systemd service idea today.  One issue I am assuming I&#39;d need to solve is bringing up the new wifi interface before I reboot, I&#39;m not sure if NM will allow me to do that if the balena tunnel is running on another device however.  If you have any other suggestions or details around that approach I&#39;m listening.</p>\n<p>Thanks,<br />Brant</p>\n<a href=\"https://www.balena-cloud.com?hidden=reply&source=flowdock&flow=rulemotion/public-s-community&thread=TAz9aNXmYye6c4FeZGg-7MmHznc&hmac=d430d2534f80fa099bd2556deb1facc82d5dff927a1d6bec08e33a33e81466fc\" target=\"_blank\" rel=\"noopener noreferrer\"></a>",
-        "created_at": 1546612197.276,
-        "error_type": null,
-        "id": "msg_284xm4z",
-        "is_draft": false,
-        "is_inbound": false,
-        "metadata": {
-          "headers": {
-            "in_reply_to": "287f6fb565446cd6c9255a5bb1c6e3c9@frontapp.com"
-          }
-        },
-        "recipients": [
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_2yqwmh"
-              }
-            },
-            "handle": "423a0f350b6f1102",
-            "role": "from"
-          },
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_8rhkb7"
-              }
-            },
-            "handle": "BrantR",
-            "role": "to"
-          }
-        ],
-        "text": "Hi dt-rush,\nTo run the commands on the host OS what we do is generate bash scripts at runtime using the users parameters (stored in /data) and before we reboot the device we run the script. So they are running from the shell using the Command::new() portion of std::process::Command from Rust. \nFor some additional information about how the dockerfile looks here are the packages we are pulling in as well as the NetworkManager.service mask:\n---Snip---\nFROM balenalib/amd64-ubuntu\nENV INITSYSTEM on\nRUN apt-get update\nRUN apt-get install -y dnsmasq wireless-tools vim file udhcpd network-manager \\\n&& systemctl mask NetworkManager.service \\\n&& apt-get clean \\\n&& rm -rf /var/lib/apt/lists/*\n---Snip---\nThe rest is just some application specific stuff to put files in the container and run it.\nIll look into the systemd service idea today. One issue I am assuming I'd need to solve is bringing up the new wifi interface before I reboot, I'm not sure if NM will allow me to do that if the balena tunnel is running on another device however. If you have any other suggestions or details around that approach I'm listening.\nThanks,\nBrant",
-        "type": "custom"
-      },
       "recipient": {
         "_links": {
           "related": {

--- a/test/integration/webhooks/intercom-rule-reopen/stubs/1/messages-msg-284-xm-4-z.json
+++ b/test/integration/webhooks/intercom-rule-reopen/stubs/1/messages-msg-284-xm-4-z.json
@@ -1,0 +1,44 @@
+{
+    "_links": {
+      "related": {
+        "conversation": "https://api2.frontapp.com/conversations/cnv_16ax9l7"
+      },
+      "self": "https://api2.frontapp.com/messages/msg_284xm4z"
+    },
+    "attachments": [],
+    "author": null,
+    "blurb": "",
+    "body": "<p>Hi dt-rush,<br />To run the commands on the host OS what we do is generate bash scripts at runtime using the users parameters (stored in /data) and before we reboot the device we run the script.  So they are running from the shell using the Command::new() portion of std::process::Command from Rust.  </p>\n<p>For some additional information about how the dockerfile looks here are the packages we are pulling in as well as the NetworkManager.service mask:</p>\n<p>---Snip---<br />FROM balenalib/amd64-ubuntu</p>\n<p>ENV INITSYSTEM on</p>\n<p>RUN apt-get update</p>\n<p>RUN apt-get install -y dnsmasq wireless-tools vim file udhcpd network-manager \\<br />    &amp;&amp; systemctl mask NetworkManager.service \\<br />    &amp;&amp; apt-get clean \\<br />    &amp;&amp; rm -rf /var/lib/apt/lists/*<br />---Snip---</p>\n<p>The rest is just some application specific stuff to put files in the container and run it.</p>\n<p>Ill look into the systemd service idea today.  One issue I am assuming I&#39;d need to solve is bringing up the new wifi interface before I reboot, I&#39;m not sure if NM will allow me to do that if the balena tunnel is running on another device however.  If you have any other suggestions or details around that approach I&#39;m listening.</p>\n<p>Thanks,<br />Brant</p>\n<a href=\"https://www.balena-cloud.com?hidden=reply&source=flowdock&flow=rulemotion/public-s-community&thread=TAz9aNXmYye6c4FeZGg-7MmHznc&hmac=d430d2534f80fa099bd2556deb1facc82d5dff927a1d6bec08e33a33e81466fc\" target=\"_blank\" rel=\"noopener noreferrer\"></a>",
+    "created_at": 1546612197.276,
+    "error_type": null,
+    "id": "msg_284xm4z",
+    "is_draft": false,
+    "is_inbound": false,
+    "metadata": {
+      "headers": {
+        "in_reply_to": "287f6fb565446cd6c9255a5bb1c6e3c9@frontapp.com"
+      }
+    },
+    "recipients": [
+      {
+        "_links": {
+          "related": {
+            "contact": "https://api2.frontapp.com/contacts/crd_2yqwmh"
+          }
+        },
+        "handle": "423a0f350b6f1102",
+        "role": "from"
+      },
+      {
+        "_links": {
+          "related": {
+            "contact": "https://api2.frontapp.com/contacts/crd_8rhkb7"
+          }
+        },
+        "handle": "BrantR",
+        "role": "to"
+      }
+    ],
+    "text": "Hi dt-rush,\nTo run the commands on the host OS what we do is generate bash scripts at runtime using the users parameters (stored in /data) and before we reboot the device we run the script. So they are running from the shell using the Command::new() portion of std::process::Command from Rust. \nFor some additional information about how the dockerfile looks here are the packages we are pulling in as well as the NetworkManager.service mask:\n---Snip---\nFROM balenalib/amd64-ubuntu\nENV INITSYSTEM on\nRUN apt-get update\nRUN apt-get install -y dnsmasq wireless-tools vim file udhcpd network-manager \\\n&& systemctl mask NetworkManager.service \\\n&& apt-get clean \\\n&& rm -rf /var/lib/apt/lists/*\n---Snip---\nThe rest is just some application specific stuff to put files in the container and run it.\nIll look into the systemd service idea today. One issue I am assuming I'd need to solve is bringing up the new wifi interface before I reboot, I'm not sure if NM will allow me to do that if the balena tunnel is running on another device however. If you have any other suggestions or details around that approach I'm listening.\nThanks,\nBrant",
+    "type": "custom"
+}

--- a/test/integration/webhooks/intercom-unknown-inbound-message-archive/stubs/1/messages-msg-27-dmk-4-b.json
+++ b/test/integration/webhooks/intercom-unknown-inbound-message-archive/stubs/1/messages-msg-27-dmk-4-b.json
@@ -1,0 +1,42 @@
+{
+    "_links": {
+      "self": "https://api2.frontapp.com/messages/msg_27dmk4b",
+      "related": {
+        "conversation": "https://api2.frontapp.com/conversations/cnv_16263rn"
+      }
+    },
+    "id": "msg_27dmk4b",
+    "type": "intercom",
+    "is_inbound": true,
+    "created_at": 1545916510,
+    "blurb": " Test test ",
+    "body": "<div><p>Test test</p>\n</div>",
+    "text": "Test test",
+    "is_draft": false,
+    "error_type": null,
+    "metadata": {
+      "intercom_url": "https://app.intercom.io/a/apps/yg02r5dz/inbox/conversation/20197789205"
+    },
+    "author": null,
+    "recipients": [
+      {
+        "_links": {
+          "related": {
+            "contact": null
+          }
+        },
+        "handle": "5457936368f6f465d7002858",
+        "role": "from"
+      },
+      {
+        "_links": {
+          "related": {
+            "contact": "https://api2.frontapp.com/contacts/crd_5gqtnd"
+          }
+        },
+        "handle": "yg02r5dz",
+        "role": "to"
+      }
+    ],
+    "attachments": []
+}

--- a/test/integration/webhooks/outbound-private-inbox/01.json
+++ b/test/integration/webhooks/outbound-private-inbox/01.json
@@ -57,7 +57,6 @@
         "role": "to"
       },
       "tags": [],
-      "last_message": {},
       "created_at": 1539209337.175,
       "is_private": false
     },

--- a/test/integration/webhooks/outbound-private-inbox/02.json
+++ b/test/integration/webhooks/outbound-private-inbox/02.json
@@ -25,7 +25,8 @@
           "followers": "https://api2.frontapp.com/conversations/cnv_11sfzr7/followers",
           "messages": "https://api2.frontapp.com/conversations/cnv_11sfzr7/messages",
           "comments": "https://api2.frontapp.com/conversations/cnv_11sfzr7/comments",
-          "inboxes": "https://api2.frontapp.com/conversations/cnv_11sfzr7/inboxes"
+          "inboxes": "https://api2.frontapp.com/conversations/cnv_11sfzr7/inboxes",
+          "last_message": "https://api2.frontapp.com/messages/msg_1y9kf8r"
         }
       },
       "id": "cnv_11sfzr7",
@@ -57,61 +58,6 @@
         "role": "to"
       },
       "tags": [],
-      "last_message": {
-        "_links": {
-          "self": "https://api2.frontapp.com/messages/msg_1y9kf8r",
-          "related": {
-            "conversation": "https://api2.frontapp.com/conversations/cnv_11sfzr7"
-          }
-        },
-        "id": "msg_1y9kf8r",
-        "type": "email",
-        "is_inbound": false,
-        "created_at": 1539209361.921,
-        "blurb": "Hello ",
-        "body": "<div>Hello</div><br><div class=\"front-signature fa-uid_3261ad35206a43895d965cefeb9a22c2\">—<br />Juan Cruz Viotti,<div>Software Engineer, Resin.io (https://resin.io)</div><div>twt: @resin_io</div></div>",
-        "text": "Hello\n",
-        "is_draft": false,
-        "error_type": null,
-        "metadata": {},
-        "author": {
-          "_links": {
-            "self": "https://api2.frontapp.com/teammates/tea_grc",
-            "related": {
-              "inboxes": "https://api2.frontapp.com/teammates/tea_grc/inboxes",
-              "conversations": "https://api2.frontapp.com/teammates/tea_grc/conversations"
-            }
-          },
-          "id": "tea_grc",
-          "email": "juan@resin.io",
-          "username": "jviotti",
-          "first_name": "Juan Cruz",
-          "last_name": "Viotti",
-          "is_admin": true,
-          "is_available": true
-        },
-        "recipients": [
-          {
-            "_links": {
-              "related": {
-                "contact": null
-              }
-            },
-            "handle": "test@resin.io",
-            "role": "from"
-          },
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_5ef35"
-              }
-            },
-            "handle": "juan@resin.io",
-            "role": "to"
-          }
-        ],
-        "attachments": []
-      },
       "created_at": 1539209337.175,
       "is_private": false
     },

--- a/test/integration/webhooks/outbound-private-inbox/stubs/1/messages-msg-1-y-9-kf-8-r.json
+++ b/test/integration/webhooks/outbound-private-inbox/stubs/1/messages-msg-1-y-9-kf-8-r.json
@@ -1,0 +1,55 @@
+{
+    "_links": {
+      "self": "https://api2.frontapp.com/messages/msg_1y9kf8r",
+      "related": {
+        "conversation": "https://api2.frontapp.com/conversations/cnv_11sfzr7"
+      }
+    },
+    "id": "msg_1y9kf8r",
+    "type": "email",
+    "is_inbound": false,
+    "created_at": 1539209361.921,
+    "blurb": "Hello ",
+    "body": "<div>Hello</div><br><div class=\"front-signature fa-uid_3261ad35206a43895d965cefeb9a22c2\">—<br />Juan Cruz Viotti,<div>Software Engineer, Resin.io (https://resin.io)</div><div>twt: @resin_io</div></div>",
+    "text": "Hello\n",
+    "is_draft": false,
+    "error_type": null,
+    "metadata": {},
+    "author": {
+      "_links": {
+        "self": "https://api2.frontapp.com/teammates/tea_grc",
+        "related": {
+          "inboxes": "https://api2.frontapp.com/teammates/tea_grc/inboxes",
+          "conversations": "https://api2.frontapp.com/teammates/tea_grc/conversations"
+        }
+      },
+      "id": "tea_grc",
+      "email": "juan@resin.io",
+      "username": "jviotti",
+      "first_name": "Juan Cruz",
+      "last_name": "Viotti",
+      "is_admin": true,
+      "is_available": true
+    },
+    "recipients": [
+      {
+        "_links": {
+          "related": {
+            "contact": null
+          }
+        },
+        "handle": "test@resin.io",
+        "role": "from"
+      },
+      {
+        "_links": {
+          "related": {
+            "contact": "https://api2.frontapp.com/contacts/crd_5ef35"
+          }
+        },
+        "handle": "juan@resin.io",
+        "role": "to"
+      }
+    ],
+    "attachments": []
+}

--- a/test/integration/webhooks/outbound/01.json
+++ b/test/integration/webhooks/outbound/01.json
@@ -57,7 +57,6 @@
         "role": "to"
       },
       "tags": [],
-      "last_message": {},
       "created_at": 1539209337.175,
       "is_private": false
     },

--- a/test/integration/webhooks/outbound/02.json
+++ b/test/integration/webhooks/outbound/02.json
@@ -25,7 +25,8 @@
           "followers": "https://api2.frontapp.com/conversations/cnv_11sfzr7/followers",
           "messages": "https://api2.frontapp.com/conversations/cnv_11sfzr7/messages",
           "comments": "https://api2.frontapp.com/conversations/cnv_11sfzr7/comments",
-          "inboxes": "https://api2.frontapp.com/conversations/cnv_11sfzr7/inboxes"
+          "inboxes": "https://api2.frontapp.com/conversations/cnv_11sfzr7/inboxes",
+          "last_message": "https://api2.frontapp.com/messages/msg_1y9kf8r"
         }
       },
       "id": "cnv_11sfzr7",
@@ -57,61 +58,6 @@
         "role": "to"
       },
       "tags": [],
-      "last_message": {
-        "_links": {
-          "self": "https://api2.frontapp.com/messages/msg_1y9kf8r",
-          "related": {
-            "conversation": "https://api2.frontapp.com/conversations/cnv_11sfzr7"
-          }
-        },
-        "id": "msg_1y9kf8r",
-        "type": "email",
-        "is_inbound": false,
-        "created_at": 1539209361.921,
-        "blurb": "Hello ",
-        "body": "<div>Hello</div><br><div class=\"front-signature fa-uid_3261ad35206a43895d965cefeb9a22c2\">—<br />Juan Cruz Viotti,<div>Software Engineer, Resin.io (https://resin.io)</div><div>twt: @resin_io</div></div>",
-        "text": "Hello\n",
-        "is_draft": false,
-        "error_type": null,
-        "metadata": {},
-        "author": {
-          "_links": {
-            "self": "https://api2.frontapp.com/teammates/tea_grc",
-            "related": {
-              "inboxes": "https://api2.frontapp.com/teammates/tea_grc/inboxes",
-              "conversations": "https://api2.frontapp.com/teammates/tea_grc/conversations"
-            }
-          },
-          "id": "tea_grc",
-          "email": "juan@resin.io",
-          "username": "jviotti",
-          "first_name": "Juan Cruz",
-          "last_name": "Viotti",
-          "is_admin": true,
-          "is_available": true
-        },
-        "recipients": [
-          {
-            "_links": {
-              "related": {
-                "contact": null
-              }
-            },
-            "handle": "test@resin.io",
-            "role": "from"
-          },
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_5ef35"
-              }
-            },
-            "handle": "juan@resin.io",
-            "role": "to"
-          }
-        ],
-        "attachments": []
-      },
       "created_at": 1539209337.175,
       "is_private": false
     },

--- a/test/integration/webhooks/outbound/stubs/2/messages-msg-1-y-9-kf-8-r.json
+++ b/test/integration/webhooks/outbound/stubs/2/messages-msg-1-y-9-kf-8-r.json
@@ -1,0 +1,55 @@
+{
+    "_links": {
+      "self": "https://api2.frontapp.com/messages/msg_1y9kf8r",
+      "related": {
+        "conversation": "https://api2.frontapp.com/conversations/cnv_11sfzr7"
+      }
+    },
+    "id": "msg_1y9kf8r",
+    "type": "email",
+    "is_inbound": false,
+    "created_at": 1539209361.921,
+    "blurb": "Hello ",
+    "body": "<div>Hello</div><br><div class=\"front-signature fa-uid_3261ad35206a43895d965cefeb9a22c2\">—<br />Juan Cruz Viotti,<div>Software Engineer, Resin.io (https://resin.io)</div><div>twt: @resin_io</div></div>",
+    "text": "Hello\n",
+    "is_draft": false,
+    "error_type": null,
+    "metadata": {},
+    "author": {
+      "_links": {
+        "self": "https://api2.frontapp.com/teammates/tea_grc",
+        "related": {
+          "inboxes": "https://api2.frontapp.com/teammates/tea_grc/inboxes",
+          "conversations": "https://api2.frontapp.com/teammates/tea_grc/conversations"
+        }
+      },
+      "id": "tea_grc",
+      "email": "juan@resin.io",
+      "username": "jviotti",
+      "first_name": "Juan Cruz",
+      "last_name": "Viotti",
+      "is_admin": true,
+      "is_available": true
+    },
+    "recipients": [
+      {
+        "_links": {
+          "related": {
+            "contact": null
+          }
+        },
+        "handle": "test@resin.io",
+        "role": "from"
+      },
+      {
+        "_links": {
+          "related": {
+            "contact": "https://api2.frontapp.com/contacts/crd_5ef35"
+          }
+        },
+        "handle": "juan@resin.io",
+        "role": "to"
+      }
+    ],
+    "attachments": []
+}

--- a/test/integration/webhooks/reminder/01.json
+++ b/test/integration/webhooks/reminder/01.json
@@ -26,7 +26,8 @@
           "events": "https://api2.frontapp.com/conversations/cnv_151xwvf/events",
           "followers": "https://api2.frontapp.com/conversations/cnv_151xwvf/followers",
           "inboxes": "https://api2.frontapp.com/conversations/cnv_151xwvf/inboxes",
-          "messages": "https://api2.frontapp.com/conversations/cnv_151xwvf/messages"
+          "messages": "https://api2.frontapp.com/conversations/cnv_151xwvf/messages",
+          "last_message": "https://api2.frontapp.com/messages/msg_26k77bn"
         },
         "self": "https://api2.frontapp.com/conversations/cnv_151xwvf"
       },
@@ -34,48 +35,6 @@
       "created_at": 1544146000.378,
       "id": "cnv_151xwvf",
       "is_private": false,
-      "last_message": {
-        "_links": {
-          "related": {
-            "conversation": "https://api2.frontapp.com/conversations/cnv_151xwvf"
-          },
-          "self": "https://api2.frontapp.com/messages/msg_26k77bn"
-        },
-        "attachments": [],
-        "author": null,
-        "blurb": " No worries. I've worked around it for now by pinning to an older base image. ",
-        "body": "<div><p>No worries. I've worked around it for now by pinning to an older base image.</p>\n</div>",
-        "created_at": 1545157973,
-        "error_type": null,
-        "id": "msg_26k77bn",
-        "is_draft": false,
-        "is_inbound": true,
-        "metadata": {
-          "intercom_url": "https://app.intercom.io/a/apps/yg02r5dz/inbox/conversation/19917193258"
-        },
-        "recipients": [
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_166upl"
-              }
-            },
-            "handle": "57a3a9f3006b38ab3a00004a",
-            "role": "from"
-          },
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_5gqtnd"
-              }
-            },
-            "handle": "yg02r5dz",
-            "role": "to"
-          }
-        ],
-        "text": "No worries. I've worked around it for now by pinning to an older base image. ",
-        "type": "intercom"
-      },
       "recipient": {
         "_links": {
           "related": {

--- a/test/integration/webhooks/reminder/02.json
+++ b/test/integration/webhooks/reminder/02.json
@@ -26,7 +26,8 @@
           "events": "https://api2.frontapp.com/conversations/cnv_151xwvf/events",
           "followers": "https://api2.frontapp.com/conversations/cnv_151xwvf/followers",
           "inboxes": "https://api2.frontapp.com/conversations/cnv_151xwvf/inboxes",
-          "messages": "https://api2.frontapp.com/conversations/cnv_151xwvf/messages"
+          "messages": "https://api2.frontapp.com/conversations/cnv_151xwvf/messages",
+          "last_message": "https://api2.frontapp.com/messages/msg_26k77bn"
         },
         "self": "https://api2.frontapp.com/conversations/cnv_151xwvf"
       },
@@ -34,48 +35,6 @@
       "created_at": 1544146000.378,
       "id": "cnv_151xwvf",
       "is_private": false,
-      "last_message": {
-        "_links": {
-          "related": {
-            "conversation": "https://api2.frontapp.com/conversations/cnv_151xwvf"
-          },
-          "self": "https://api2.frontapp.com/messages/msg_26k77bn"
-        },
-        "attachments": [],
-        "author": null,
-        "blurb": " No worries. I've worked around it for now by pinning to an older base image. ",
-        "body": "<div><p>No worries. I've worked around it for now by pinning to an older base image.</p>\n</div>",
-        "created_at": 1545157973,
-        "error_type": null,
-        "id": "msg_26k77bn",
-        "is_draft": false,
-        "is_inbound": true,
-        "metadata": {
-          "intercom_url": "https://app.intercom.io/a/apps/yg02r5dz/inbox/conversation/19917193258"
-        },
-        "recipients": [
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_166upl"
-              }
-            },
-            "handle": "57a3a9f3006b38ab3a00004a",
-            "role": "from"
-          },
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_5gqtnd"
-              }
-            },
-            "handle": "yg02r5dz",
-            "role": "to"
-          }
-        ],
-        "text": "No worries. I've worked around it for now by pinning to an older base image. ",
-        "type": "intercom"
-      },
       "recipient": {
         "_links": {
           "related": {

--- a/test/integration/webhooks/reminder/stubs/1/messages-msg-26-k-77-bn.json
+++ b/test/integration/webhooks/reminder/stubs/1/messages-msg-26-k-77-bn.json
@@ -1,0 +1,42 @@
+{
+    "_links": {
+      "related": {
+        "conversation": "https://api2.frontapp.com/conversations/cnv_151xwvf"
+      },
+      "self": "https://api2.frontapp.com/messages/msg_26k77bn"
+    },
+    "attachments": [],
+    "author": null,
+    "blurb": " No worries. I've worked around it for now by pinning to an older base image. ",
+    "body": "<div><p>No worries. I've worked around it for now by pinning to an older base image.</p>\n</div>",
+    "created_at": 1545157973,
+    "error_type": null,
+    "id": "msg_26k77bn",
+    "is_draft": false,
+    "is_inbound": true,
+    "metadata": {
+      "intercom_url": "https://app.intercom.io/a/apps/yg02r5dz/inbox/conversation/19917193258"
+    },
+    "recipients": [
+      {
+        "_links": {
+          "related": {
+            "contact": "https://api2.frontapp.com/contacts/crd_166upl"
+          }
+        },
+        "handle": "57a3a9f3006b38ab3a00004a",
+        "role": "from"
+      },
+      {
+        "_links": {
+          "related": {
+            "contact": "https://api2.frontapp.com/contacts/crd_5gqtnd"
+          }
+        },
+        "handle": "yg02r5dz",
+        "role": "to"
+      }
+    ],
+    "text": "No worries. I've worked around it for now by pinning to an older base image. ",
+    "type": "intercom"
+}

--- a/test/integration/webhooks/sales-inbound-whisper-outbound/01.json
+++ b/test/integration/webhooks/sales-inbound-whisper-outbound/01.json
@@ -25,7 +25,8 @@
           "followers": "https://api2.frontapp.com/conversations/cnv_23kgkub/followers",
           "messages": "https://api2.frontapp.com/conversations/cnv_23kgkub/messages",
           "comments": "https://api2.frontapp.com/conversations/cnv_23kgkub/comments",
-          "inboxes": "https://api2.frontapp.com/conversations/cnv_23kgkub/inboxes"
+          "inboxes": "https://api2.frontapp.com/conversations/cnv_23kgkub/inboxes",
+          "last_message": "https://api2.frontapp.com/messages/msg_44t0vsz"
         }
       },
       "id": "cnv_23kgkub",
@@ -42,56 +43,6 @@
         "role": "from"
       },
       "tags": [],
-      "last_message": {
-        "_links": {
-          "self": "https://api2.frontapp.com/messages/msg_44t0vsz",
-          "related": {
-            "conversation": "https://api2.frontapp.com/conversations/cnv_23kgkub"
-          }
-        },
-        "id": "msg_44t0vsz",
-        "type": "email",
-        "is_inbound": true,
-        "created_at": 1563538811.786,
-        "blurb": "Test -- Juan Cruz Viotti Software Engineer https://www.jviotti.com ",
-        "body": "Test<br><br>-- <br>Juan Cruz Viotti<br>Software Engineer<br><a href=\"https://www.jviotti.com\" target=\"_blank\" rel=\"noopener noreferrer\">https://www.jviotti.com</a><br>",
-        "text": "Test\n\n-- \nJuan Cruz Viotti\nSoftware Engineer\nhttps://www.jviotti.com\n",
-        "is_draft": false,
-        "error_type": "id_usurpation",
-        "metadata": {},
-        "author": null,
-        "recipients": [
-          {
-            "_links": {
-              "related": {
-                "contact": null
-              }
-            },
-            "handle": "jv@jviotti.com",
-            "role": "from"
-          },
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_8jbeiz"
-              }
-            },
-            "handle": "sales@balena.io",
-            "role": "to"
-          }
-        ],
-        "attachments": [
-          {
-            "url": "https://api2.frontapp.com/download/fil_691uv7n",
-            "filename": "signature.asc",
-            "content_type": "application/pgp-signature",
-            "size": 849,
-            "metadata": {
-              "is_inline": false
-            }
-          }
-        ]
-      },
       "created_at": 1563538811.885,
       "is_private": false
     },

--- a/test/integration/webhooks/sales-inbound-whisper-outbound/02.json
+++ b/test/integration/webhooks/sales-inbound-whisper-outbound/02.json
@@ -25,7 +25,8 @@
           "followers": "https://api2.frontapp.com/conversations/cnv_23kgkub/followers",
           "messages": "https://api2.frontapp.com/conversations/cnv_23kgkub/messages",
           "comments": "https://api2.frontapp.com/conversations/cnv_23kgkub/comments",
-          "inboxes": "https://api2.frontapp.com/conversations/cnv_23kgkub/inboxes"
+          "inboxes": "https://api2.frontapp.com/conversations/cnv_23kgkub/inboxes",
+          "last_message": "https://api2.frontapp.com/messages/msg_44t0vsz"
         }
       },
       "id": "cnv_23kgkub",
@@ -42,56 +43,6 @@
         "role": "from"
       },
       "tags": [],
-      "last_message": {
-        "_links": {
-          "self": "https://api2.frontapp.com/messages/msg_44t0vsz",
-          "related": {
-            "conversation": "https://api2.frontapp.com/conversations/cnv_23kgkub"
-          }
-        },
-        "id": "msg_44t0vsz",
-        "type": "email",
-        "is_inbound": true,
-        "created_at": 1563538811.786,
-        "blurb": "Test -- Juan Cruz Viotti Software Engineer https://www.jviotti.com ",
-        "body": "Test<br><br>-- <br>Juan Cruz Viotti<br>Software Engineer<br><a href=\"https://www.jviotti.com\" target=\"_blank\" rel=\"noopener noreferrer\">https://www.jviotti.com</a><br>",
-        "text": "Test\n\n-- \nJuan Cruz Viotti\nSoftware Engineer\nhttps://www.jviotti.com\n",
-        "is_draft": false,
-        "error_type": "id_usurpation",
-        "metadata": {},
-        "author": null,
-        "recipients": [
-          {
-            "_links": {
-              "related": {
-                "contact": null
-              }
-            },
-            "handle": "jv@jviotti.com",
-            "role": "from"
-          },
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_8jbeiz"
-              }
-            },
-            "handle": "sales@balena.io",
-            "role": "to"
-          }
-        ],
-        "attachments": [
-          {
-            "url": "https://api2.frontapp.com/download/fil_691uv7n",
-            "filename": "signature.asc",
-            "content_type": "application/pgp-signature",
-            "size": 849,
-            "metadata": {
-              "is_inline": false
-            }
-          }
-        ]
-      },
       "created_at": 1563538811.885,
       "is_private": false
     },

--- a/test/integration/webhooks/sales-inbound-whisper-outbound/03.json
+++ b/test/integration/webhooks/sales-inbound-whisper-outbound/03.json
@@ -25,7 +25,8 @@
           "followers": "https://api2.frontapp.com/conversations/cnv_23kgkub/followers",
           "messages": "https://api2.frontapp.com/conversations/cnv_23kgkub/messages",
           "comments": "https://api2.frontapp.com/conversations/cnv_23kgkub/comments",
-          "inboxes": "https://api2.frontapp.com/conversations/cnv_23kgkub/inboxes"
+          "inboxes": "https://api2.frontapp.com/conversations/cnv_23kgkub/inboxes",
+          "last_message": "https://api2.frontapp.com/messages/msg_44t0vsz"
         }
       },
       "id": "cnv_23kgkub",
@@ -42,56 +43,6 @@
         "role": "from"
       },
       "tags": [],
-      "last_message": {
-        "_links": {
-          "self": "https://api2.frontapp.com/messages/msg_44t0vsz",
-          "related": {
-            "conversation": "https://api2.frontapp.com/conversations/cnv_23kgkub"
-          }
-        },
-        "id": "msg_44t0vsz",
-        "type": "email",
-        "is_inbound": true,
-        "created_at": 1563538811.786,
-        "blurb": "Test -- Juan Cruz Viotti Software Engineer https://www.jviotti.com ",
-        "body": "Test<br><br>-- <br>Juan Cruz Viotti<br>Software Engineer<br><a href=\"https://www.jviotti.com\" target=\"_blank\" rel=\"noopener noreferrer\">https://www.jviotti.com</a><br>",
-        "text": "Test\n\n-- \nJuan Cruz Viotti\nSoftware Engineer\nhttps://www.jviotti.com\n",
-        "is_draft": false,
-        "error_type": "id_usurpation",
-        "metadata": {},
-        "author": null,
-        "recipients": [
-          {
-            "_links": {
-              "related": {
-                "contact": null
-              }
-            },
-            "handle": "jv@jviotti.com",
-            "role": "from"
-          },
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_8jbeiz"
-              }
-            },
-            "handle": "sales@balena.io",
-            "role": "to"
-          }
-        ],
-        "attachments": [
-          {
-            "url": "https://api2.frontapp.com/download/fil_691uv7n",
-            "filename": "signature.asc",
-            "content_type": "application/pgp-signature",
-            "size": 849,
-            "metadata": {
-              "is_inline": false
-            }
-          }
-        ]
-      },
       "created_at": 1563538811.885,
       "is_private": false
     },

--- a/test/integration/webhooks/sales-inbound-whisper-outbound/04.json
+++ b/test/integration/webhooks/sales-inbound-whisper-outbound/04.json
@@ -25,7 +25,8 @@
           "followers": "https://api2.frontapp.com/conversations/cnv_23kgkub/followers",
           "messages": "https://api2.frontapp.com/conversations/cnv_23kgkub/messages",
           "comments": "https://api2.frontapp.com/conversations/cnv_23kgkub/comments",
-          "inboxes": "https://api2.frontapp.com/conversations/cnv_23kgkub/inboxes"
+          "inboxes": "https://api2.frontapp.com/conversations/cnv_23kgkub/inboxes",
+          "last_message": "https://api2.frontapp.com/messages/msg_44t0vsz"
         }
       },
       "id": "cnv_23kgkub",
@@ -58,56 +59,6 @@
         "role": "to"
       },
       "tags": [],
-      "last_message": {
-        "_links": {
-          "self": "https://api2.frontapp.com/messages/msg_44t0vsz",
-          "related": {
-            "conversation": "https://api2.frontapp.com/conversations/cnv_23kgkub"
-          }
-        },
-        "id": "msg_44t0vsz",
-        "type": "email",
-        "is_inbound": true,
-        "created_at": 1563538811.786,
-        "blurb": "Test -- Juan Cruz Viotti Software Engineer https://www.jviotti.com ",
-        "body": "Test<br><br>-- <br>Juan Cruz Viotti<br>Software Engineer<br><a href=\"https://www.jviotti.com\" target=\"_blank\" rel=\"noopener noreferrer\">https://www.jviotti.com</a><br>",
-        "text": "Test\n\n-- \nJuan Cruz Viotti\nSoftware Engineer\nhttps://www.jviotti.com\n",
-        "is_draft": false,
-        "error_type": "id_usurpation",
-        "metadata": {},
-        "author": null,
-        "recipients": [
-          {
-            "_links": {
-              "related": {
-                "contact": null
-              }
-            },
-            "handle": "jv@jviotti.com",
-            "role": "from"
-          },
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_8jbeiz"
-              }
-            },
-            "handle": "sales@balena.io",
-            "role": "to"
-          }
-        ],
-        "attachments": [
-          {
-            "url": "https://api2.frontapp.com/download/fil_691uv7n",
-            "filename": "signature.asc",
-            "content_type": "application/pgp-signature",
-            "size": 849,
-            "metadata": {
-              "is_inline": false
-            }
-          }
-        ]
-      },
       "created_at": 1563538811.885,
       "is_private": false
     },

--- a/test/integration/webhooks/sales-inbound-whisper-outbound/05.json
+++ b/test/integration/webhooks/sales-inbound-whisper-outbound/05.json
@@ -25,7 +25,8 @@
           "followers": "https://api2.frontapp.com/conversations/cnv_23kgkub/followers",
           "messages": "https://api2.frontapp.com/conversations/cnv_23kgkub/messages",
           "comments": "https://api2.frontapp.com/conversations/cnv_23kgkub/comments",
-          "inboxes": "https://api2.frontapp.com/conversations/cnv_23kgkub/inboxes"
+          "inboxes": "https://api2.frontapp.com/conversations/cnv_23kgkub/inboxes",
+          "last_message": "https://api2.frontapp.com/messages/msg_44t177n"
         }
       },
       "id": "cnv_23kgkub",
@@ -58,62 +59,6 @@
         "role": "to"
       },
       "tags": [],
-      "last_message": {
-        "_links": {
-          "self": "https://api2.frontapp.com/messages/msg_44t177n",
-          "related": {
-            "conversation": "https://api2.frontapp.com/conversations/cnv_23kgkub"
-          }
-        },
-        "id": "msg_44t177n",
-        "type": "email",
-        "is_inbound": false,
-        "created_at": 1563538852.296,
-        "blurb": "Test email reply",
-        "body": "<div>Test email reply</div><br><div class=\"front-signature fa-uid_3ceb624a81164f46da606d90470c85fb\"><div>—</div><div>Juan Cruz Viotti,</div><div>Software Engineer, Resin.io (https://resin.io)</div><div>twt: @resin_io</div></div><br><blockquote type=\"cite\" class=\"front-blockquote\">On July 19, 2019, 1:20 PM GMT+1 <a href=\"mailto:jv@jviotti.com\" target=\"_blank\" rel=\"noopener noreferrer\">jv@jviotti.com</a> wrote:<br /><br /><div id=\"fae_44t177n-n94dtz\">Test<br /><br />-- <br />Juan Cruz Viotti<br />Software Engineer<br /><a rel=\"noopener noreferrer\" href=\"https://www.jviotti.com/\" target=\"_blank\">https://www.jviotti.com</a><br /></div></blockquote>",
-        "text": "Test email reply",
-        "is_draft": false,
-        "error_type": null,
-        "metadata": {},
-        "author": {
-          "_links": {
-            "self": "https://api2.frontapp.com/teammates/tea_grc",
-            "related": {
-              "inboxes": "https://api2.frontapp.com/teammates/tea_grc/inboxes",
-              "conversations": "https://api2.frontapp.com/teammates/tea_grc/conversations"
-            }
-          },
-          "id": "tea_grc",
-          "email": "juan@balena.io",
-          "username": "jviotti",
-          "first_name": "Juan Cruz",
-          "last_name": "Viotti",
-          "is_admin": true,
-          "is_available": true,
-          "is_blocked": false
-        },
-        "recipients": [
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_8jbeiz"
-              }
-            },
-            "handle": "sales@balena.io",
-            "role": "from"
-          },
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_chkozn"
-              }
-            },
-            "handle": "jv@jviotti.com",
-            "role": "to"
-          }
-        ],
-        "attachments": []
-      },
       "created_at": 1563538811.885,
       "is_private": false
     },

--- a/test/integration/webhooks/sales-inbound-whisper-outbound/stubs/1/messages-msg-44-t-0-vsz.json
+++ b/test/integration/webhooks/sales-inbound-whisper-outbound/stubs/1/messages-msg-44-t-0-vsz.json
@@ -1,0 +1,50 @@
+{
+    "_links": {
+      "self": "https://api2.frontapp.com/messages/msg_44t0vsz",
+      "related": {
+        "conversation": "https://api2.frontapp.com/conversations/cnv_23kgkub"
+      }
+    },
+    "id": "msg_44t0vsz",
+    "type": "email",
+    "is_inbound": true,
+    "created_at": 1563538811.786,
+    "blurb": "Test -- Juan Cruz Viotti Software Engineer https://www.jviotti.com ",
+    "body": "Test<br><br>-- <br>Juan Cruz Viotti<br>Software Engineer<br><a href=\"https://www.jviotti.com\" target=\"_blank\" rel=\"noopener noreferrer\">https://www.jviotti.com</a><br>",
+    "text": "Test\n\n-- \nJuan Cruz Viotti\nSoftware Engineer\nhttps://www.jviotti.com\n",
+    "is_draft": false,
+    "error_type": "id_usurpation",
+    "metadata": {},
+    "author": null,
+    "recipients": [
+      {
+        "_links": {
+          "related": {
+            "contact": null
+          }
+        },
+        "handle": "jv@jviotti.com",
+        "role": "from"
+      },
+      {
+        "_links": {
+          "related": {
+            "contact": "https://api2.frontapp.com/contacts/crd_8jbeiz"
+          }
+        },
+        "handle": "sales@balena.io",
+        "role": "to"
+      }
+    ],
+    "attachments": [
+      {
+        "url": "https://api2.frontapp.com/download/fil_691uv7n",
+        "filename": "signature.asc",
+        "content_type": "application/pgp-signature",
+        "size": 849,
+        "metadata": {
+          "is_inline": false
+        }
+      }
+    ]
+}

--- a/test/integration/webhooks/sales-inbound-whisper-outbound/stubs/5/messages-msg-44-t-177-n.json
+++ b/test/integration/webhooks/sales-inbound-whisper-outbound/stubs/5/messages-msg-44-t-177-n.json
@@ -1,0 +1,56 @@
+{
+    "_links": {
+      "self": "https://api2.frontapp.com/messages/msg_44t177n",
+      "related": {
+        "conversation": "https://api2.frontapp.com/conversations/cnv_23kgkub"
+      }
+    },
+    "id": "msg_44t177n",
+    "type": "email",
+    "is_inbound": false,
+    "created_at": 1563538852.296,
+    "blurb": "Test email reply",
+    "body": "<div>Test email reply</div><br><div class=\"front-signature fa-uid_3ceb624a81164f46da606d90470c85fb\"><div>—</div><div>Juan Cruz Viotti,</div><div>Software Engineer, Resin.io (https://resin.io)</div><div>twt: @resin_io</div></div><br><blockquote type=\"cite\" class=\"front-blockquote\">On July 19, 2019, 1:20 PM GMT+1 <a href=\"mailto:jv@jviotti.com\" target=\"_blank\" rel=\"noopener noreferrer\">jv@jviotti.com</a> wrote:<br /><br /><div id=\"fae_44t177n-n94dtz\">Test<br /><br />-- <br />Juan Cruz Viotti<br />Software Engineer<br /><a rel=\"noopener noreferrer\" href=\"https://www.jviotti.com/\" target=\"_blank\">https://www.jviotti.com</a><br /></div></blockquote>",
+    "text": "Test email reply",
+    "is_draft": false,
+    "error_type": null,
+    "metadata": {},
+    "author": {
+      "_links": {
+        "self": "https://api2.frontapp.com/teammates/tea_grc",
+        "related": {
+          "inboxes": "https://api2.frontapp.com/teammates/tea_grc/inboxes",
+          "conversations": "https://api2.frontapp.com/teammates/tea_grc/conversations"
+        }
+      },
+      "id": "tea_grc",
+      "email": "juan@balena.io",
+      "username": "jviotti",
+      "first_name": "Juan Cruz",
+      "last_name": "Viotti",
+      "is_admin": true,
+      "is_available": true,
+      "is_blocked": false
+    },
+    "recipients": [
+      {
+        "_links": {
+          "related": {
+            "contact": "https://api2.frontapp.com/contacts/crd_8jbeiz"
+          }
+        },
+        "handle": "sales@balena.io",
+        "role": "from"
+      },
+      {
+        "_links": {
+          "related": {
+            "contact": "https://api2.frontapp.com/contacts/crd_chkozn"
+          }
+        },
+        "handle": "jv@jviotti.com",
+        "role": "to"
+      }
+    ],
+    "attachments": []
+}

--- a/test/integration/webhooks/unknown-inbox/01.json
+++ b/test/integration/webhooks/unknown-inbox/01.json
@@ -25,7 +25,8 @@
           "followers": "https://api2.frontapp.com/conversations/cnv_173uno3/followers",
           "messages": "https://api2.frontapp.com/conversations/cnv_173uno3/messages",
           "comments": "https://api2.frontapp.com/conversations/cnv_173uno3/comments",
-          "inboxes": "https://api2.frontapp.com/conversations/cnv_173uno3/inboxes"
+          "inboxes": "https://api2.frontapp.com/conversations/cnv_173uno3/inboxes",
+          "last_message": "https://api2.frontapp.com/messages/msg_29otzx7"
         }
       },
       "id": "cnv_173uno3",
@@ -42,48 +43,6 @@
         "role": "from"
       },
       "tags": [],
-      "last_message": {
-        "_links": {
-          "self": "https://api2.frontapp.com/messages/msg_29otzx7",
-          "related": {
-            "conversation": "https://api2.frontapp.com/conversations/cnv_173uno3"
-          }
-        },
-        "id": "msg_29otzx7",
-        "type": "intercom",
-        "is_inbound": true,
-        "created_at": 1547721760,
-        "blurb": " JF test (ignore) ",
-        "body": "<div><p>JF test (ignore)</p>\n</div>",
-        "text": "JF test (ignore)",
-        "is_draft": false,
-        "error_type": null,
-        "metadata": {
-          "intercom_url": "https://app.intercom.io/a/apps/yg02r5dz/inbox/conversation/20454527100"
-        },
-        "author": null,
-        "recipients": [
-          {
-            "_links": {
-              "related": {
-                "contact": null
-              }
-            },
-            "handle": "5457936368f6f465d7002858",
-            "role": "from"
-          },
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_5gqtnd"
-              }
-            },
-            "handle": "yg02r5dz",
-            "role": "to"
-          }
-        ],
-        "attachments": []
-      },
       "created_at": 1547721763.662,
       "is_private": false
     },

--- a/test/integration/webhooks/unknown-inbox/02.json
+++ b/test/integration/webhooks/unknown-inbox/02.json
@@ -25,7 +25,8 @@
           "followers": "https://api2.frontapp.com/conversations/cnv_173uno3/followers",
           "messages": "https://api2.frontapp.com/conversations/cnv_173uno3/messages",
           "comments": "https://api2.frontapp.com/conversations/cnv_173uno3/comments",
-          "inboxes": "https://api2.frontapp.com/conversations/cnv_173uno3/inboxes"
+          "inboxes": "https://api2.frontapp.com/conversations/cnv_173uno3/inboxes",
+          "last_message": "https://api2.frontapp.com/messages/msg_29otzx7"
         }
       },
       "id": "cnv_173uno3",
@@ -42,48 +43,6 @@
         "role": "from"
       },
       "tags": [],
-      "last_message": {
-        "_links": {
-          "self": "https://api2.frontapp.com/messages/msg_29otzx7",
-          "related": {
-            "conversation": "https://api2.frontapp.com/conversations/cnv_173uno3"
-          }
-        },
-        "id": "msg_29otzx7",
-        "type": "intercom",
-        "is_inbound": true,
-        "created_at": 1547721760,
-        "blurb": " JF test (ignore) ",
-        "body": "<div><p>JF test (ignore)</p>\n</div>",
-        "text": "JF test (ignore)",
-        "is_draft": false,
-        "error_type": null,
-        "metadata": {
-          "intercom_url": "https://app.intercom.io/a/apps/yg02r5dz/inbox/conversation/20454527100"
-        },
-        "author": null,
-        "recipients": [
-          {
-            "_links": {
-              "related": {
-                "contact": null
-              }
-            },
-            "handle": "5457936368f6f465d7002858",
-            "role": "from"
-          },
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_5gqtnd"
-              }
-            },
-            "handle": "yg02r5dz",
-            "role": "to"
-          }
-        ],
-        "attachments": []
-      },
       "created_at": 1547721763.662,
       "is_private": false
     },

--- a/test/integration/webhooks/zendesk-archive/01.json
+++ b/test/integration/webhooks/zendesk-archive/01.json
@@ -26,7 +26,8 @@
           "events": "https://api2.frontapp.com/conversations/cnv_14y4y23/events",
           "followers": "https://api2.frontapp.com/conversations/cnv_14y4y23/followers",
           "inboxes": "https://api2.frontapp.com/conversations/cnv_14y4y23/inboxes",
-          "messages": "https://api2.frontapp.com/conversations/cnv_14y4y23/messages"
+          "messages": "https://api2.frontapp.com/conversations/cnv_14y4y23/messages",
+          "last_message": "https://api2.frontapp.com/messages/msg_27pbnez"
         },
         "self": "https://api2.frontapp.com/conversations/cnv_14y4y23"
       },
@@ -34,65 +35,6 @@
       "created_at": 1544033275.734,
       "id": "cnv_14y4y23",
       "is_private": false,
-      "last_message": {
-        "_links": {
-          "related": {
-            "conversation": "https://api2.frontapp.com/conversations/cnv_14y4y23"
-          },
-          "self": "https://api2.frontapp.com/messages/msg_27pbnez"
-        },
-        "attachments": [],
-        "author": {
-          "_links": {
-            "related": {
-              "conversations": "https://api2.frontapp.com/teammates/tea_t8s/conversations",
-              "inboxes": "https://api2.frontapp.com/teammates/tea_t8s/inboxes"
-            },
-            "self": "https://api2.frontapp.com/teammates/tea_t8s"
-          },
-          "email": "giovanni@balena.io",
-          "first_name": "Giovanni",
-          "id": "tea_t8s",
-          "is_admin": false,
-          "is_available": true,
-          "last_name": "Garufi",
-          "username": "nazrhom"
-        },
-        "blurb": "",
-        "body": "<p>Hi @ppiixx @rquant,</p>\n<p>Our sincere apologies. We released 2.29 earlier last week, but it was prematurely done. Until we iron out everything on our side, the download was masked from our website, meaning that it should not be used yet. </p>\n<p>Again we apologise and we will make this version available ASAP, but given the holiday season many of my colleagues are on leave making this process slower than usual. </p>\n<p>We will keep you updated.</p>\n<a href=\"https://www.balena-cloud.com?hidden=reply&source=flowdock&flow=rulemotion/public-s-community&thread=88uJvVivV5EMfqejHWKMzm_0DqQ&hmac=afd6f1e55cff2ebbadaa29e927f84bb7fbcddbf1b6a291b6fb81282c9a1f2c89\" target=\"_blank\" rel=\"noopener noreferrer\"></a>",
-        "created_at": 1546262577.716,
-        "error_type": null,
-        "id": "msg_27pbnez",
-        "is_draft": false,
-        "is_inbound": false,
-        "metadata": {
-          "headers": {
-            "in_reply_to": "be695b1134917956a8d9c4263ed81ce7@frontapp.com"
-          }
-        },
-        "recipients": [
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_2yqwmh"
-              }
-            },
-            "handle": "423a0f350b6f1102",
-            "role": "from"
-          },
-          {
-            "_links": {
-              "related": {
-                "contact": "https://api2.frontapp.com/contacts/crd_5v78sx"
-              }
-            },
-            "handle": "rquant",
-            "role": "to"
-          }
-        ],
-        "text": "Hi @ppiixx @rquant,\nOur sincere apologies. We released 2.29 earlier last week, but it was prematurely done. Until we iron out everything on our side, the download was masked from our website, meaning that it should not be used yet. \nAgain we apologise and we will make this version available ASAP, but given the holiday season many of my colleagues are on leave making this process slower than usual. \nWe will keep you updated.",
-        "type": "custom"
-      },
       "recipient": {
         "_links": {
           "related": {


### PR DESCRIPTION
Update all translate tests that were temporarily disabled as they
still assumed the now removed last_message object was provided by
the webhook payload.

Change-type: patch
Signed-off-by: Josh Bowling <josh@monarci.com>