### PR TITLE
Query using mirror IDs with an enum

### DIFF
--- a/lib/integrations/front.ts
+++ b/lib/integrations/front.ts
@@ -94,9 +94,7 @@ const FRONT_API_PREFIXES = [
 
 // find matching elements by mirrorId
 // The mirrorId is the full URL, and it can use as the host value
-// either resin.io.api, resinio.api or api2. Running several queries to
-// avoid using a pattern match that timed out on a previous version
-// TODO: Use a worker function that accepts an enum instead of doing separate queries
+// either resin.io.api, resinio.api or api2.
 async function getElementByFuzzyMirrorId(
 	context: any,
 	type: string,
@@ -115,18 +113,23 @@ async function getElementByFuzzyMirrorId(
 	const candidateIds = FRONT_API_PREFIXES.map(
 		(prefix) => prefix + mirrorIdMatches[0],
 	);
-	const results = await Promise.all(
-		candidateIds.map(async (id) => {
-			return context.getElementByMirrorId(type, id, { pattern: true });
-		}),
-	);
-	context.log.debug('getElementByFuzzyMirrorId results', {
+
+	context.log.info('Searching for Front element by mirrorId', {
+		type,
 		mirrorId,
 		candidateIds,
-		results,
 	});
 
-	return _.compact(results)[0];
+	const result = await context.getElementByMirrorIds(type, candidateIds);
+
+	context.log.info('Front getElementByFuzzyMirrorId results', {
+		type,
+		mirrorId,
+		candidateIds,
+		result: result && result.id ? result.id : null,
+	});
+
+	return result;
 }
 
 /*

--- a/lib/integrations/front.ts
+++ b/lib/integrations/front.ts
@@ -1167,7 +1167,13 @@ export class FrontIntegration implements Integration {
 	}
 
 	public async translate(event: any): Promise<SequenceItem[]> {
+		this.context.log.info('FrontIntegration.translate event:.', {
+			event,
+		});
 		if (!this.options.token.api || !this.options.token.intercom) {
+			this.context.log.info(
+				'FrontIntegration.translate No token.api or not intercom token on env, returning.',
+			);
 			return [];
 		}
 
@@ -1241,6 +1247,10 @@ export class FrontIntegration implements Integration {
 				$eval: 'cards[0].id',
 			};
 		}
+
+		this.context.log.info(
+			'FrontIntegration.translate before getAllThreadMessages',
+		);
 
 		// Do a recap using the API
 		const remoteMessages = await getAllThreadMessages(

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@balena/jellyfish-assert": "^1.2.54",
     "@balena/jellyfish-environment": "^13.0.4",
-    "@balena/jellyfish-worker": "^33.0.38",
+    "@balena/jellyfish-worker": "^33.1.0",
     "@types/sanitize-html": "^2.6.2",
     "axios": "^0.27.2",
     "bluebird": "^3.7.2",


### PR DESCRIPTION
Improve efficiency when searching for contracts that have one of a set
of mirror IDs by using an enum instead of a pattern.

Change-type: patch
Signed-off-by: Josh Bowling <josh@monarci.com>