### PR TITLE
Add JellyfishDatabaseTimeoutError to the list of retryable errors

### DIFF
--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -1,0 +1,5 @@
+import { JellyfishError } from '@balena/jellyfish-worker';
+
+export class RetriesExhaustedError extends Error implements JellyfishError {
+	expected: boolean = false;
+}

--- a/test/unit/context-retry-wrapper.spec.ts
+++ b/test/unit/context-retry-wrapper.spec.ts
@@ -1,3 +1,4 @@
+import { RetriesExhaustedError } from '../../lib/errors';
 import { retryableContext } from '../../lib/integrations/context-retry-wrapper';
 
 describe('retryableContext', () => {
@@ -36,7 +37,8 @@ describe('retryableContext', () => {
 			await wrapper.getElementById('x');
 		} catch (error: any) {
 			const after = new Date().valueOf();
-			expect(error.message).toBe('Query read timeout');
+			expect(error instanceof RetriesExhaustedError).toBeTruthy();
+			expect(error.message).toContain('Query read timeout');
 			expect(after - now).toBeGreaterThanOrEqual(
 				options.delay * options.retries,
 			);


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Ramiro Gonzalez <ramiro.gonzalez@balena.io>