### PR TITLE
CI: Force exit integration tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "lint:fix": "balena-lint --fix lib test",
     "test": "npm run lint && npm run test:unit",
     "test:unit": "jest test/unit",
-    "test:integration": "npx jest --runInBand --bail test/integration",
+    "test:integration": "npx jest --runInBand --bail --forceExit test/integration",
     "test:compose": "docker build -t balena/jellyfish-sut:latest . && docker-compose -f docker-compose.test.yml -f docker-compose.yml up --exit-code-from=sut",
     "doc": "typedoc lib/ && touch docs/.nojekyll",
     "prepack": "npm run build",


### PR DESCRIPTION
We can remove this after moving integration code to actions and removing the broken way we test translates.

Change-type: patch
Signed-off-by: Josh Bowling <josh@monarci.com>