### PR TITLE
Change engines to >=16 to enable node 18 tests/usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/product-os/jellyfish-plugin-front"
   },
   "engines": {
-    "node": "^16.0.0"
+    "node": ">=16.0.0"
   },
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
Change-type: patch